### PR TITLE
Add placeholder tests and modules

### DIFF
--- a/action.py
+++ b/action.py
@@ -1,0 +1,4 @@
+"""Simple action module."""
+
+def ping():
+    return "action"

--- a/core.py
+++ b/core.py
@@ -1,0 +1,4 @@
+"""Simple core module."""
+
+def ping():
+    return "core"

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,0 +1,9 @@
+import importlib
+import pytest
+
+@pytest.fixture
+def action_module():
+    return importlib.import_module('action')
+
+def test_action_module_loads(action_module):
+    assert action_module.__name__ == 'action'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,9 @@
+import importlib
+import pytest
+
+@pytest.fixture
+def core_module():
+    return importlib.import_module('core')
+
+def test_core_module_loads(core_module):
+    assert core_module.__name__ == 'core'

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -1,0 +1,9 @@
+import importlib
+import pytest
+
+@pytest.fixture
+def trigger_module():
+    return importlib.import_module('trigger')
+
+def test_trigger_module_loads(trigger_module):
+    assert trigger_module.__name__ == 'trigger'

--- a/trigger.py
+++ b/trigger.py
@@ -1,0 +1,4 @@
+"""Simple trigger module."""
+
+def ping():
+    return "trigger"


### PR DESCRIPTION
## Summary
- add simple modules: `action`, `core`, and `trigger`
- add pytest infrastructure with empty `conftest.py`
- add tests ensuring the modules import correctly

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f711667d4832daf77f01a86d3608f