### PR TITLE
Initialize PyZap skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+pyzap.log

--- a/README.md
+++ b/README.md
@@ -1,26 +1,21 @@
 # PyZap
 
-PyZap is a small command line application for automating personal workflows.
+PyZap is a monolithic workflow automation tool inspired by Zapier. This repository
+contains a minimal skeleton implementing plugin-based triggers and actions,
+a command line interface, and a small Flask web dashboard.
 
-## Project Layout
+```
+pyzap/
+  core.py          - workflow engine and main loop
+  cli.py           - command line interface
+  webapp.py        - minimal Flask dashboard
+  formatter.py     - data transformation utilities
+  plugins/         - trigger and action implementations
 
-- `pyzap/` - Python package containing the library and CLI entry points.
-- `workflows/` - Example workflow files that can be enabled or customized.
-- `README.md` - Project documentation.
-
-## Usage
-
-Install the project locally and run the CLI:
-
-```bash
-pip install -e .
-pyzap --help
+config.json.example - example workflow configuration
+tests/              - pytest scaffolding
+docs/               - MkDocs documentation skeleton
 ```
 
-To enable and run a workflow:
-
-```bash
-pyzap run my_workflow
-```
-
-Workflows can be placed in the `workflows/` directory and referenced by name.
+This code base is a starting point only. Business logic for each plugin must be
+implemented along with authentication credentials for external services.

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "example-zap",
+    "trigger": {
+      "type": "gmail_poll",
+      "query": "label:inbox",
+      "interval": 60
+    },
+    "actions": [
+      {"type": "gdrive_upload", "params": {"folder_id": ""}},
+      {"type": "sheets_append", "params": {"sheet_id": "", "range": "Sheet1!A:B"}},
+      {"type": "slack_notify", "params": {"webhook_url": ""}}
+    ]
+  }
+]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# PyZap Documentation
+
+Welcome to the PyZap documentation.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,3 @@
+site_name: PyZap
+nav:
+  - Home: index.md

--- a/pyzap/__init__.py
+++ b/pyzap/__init__.py
@@ -1,0 +1,3 @@
+"""PyZap package."""
+
+__all__ = ["core", "cli", "webapp", "formatter", "plugins"]

--- a/pyzap/cli.py
+++ b/pyzap/cli.py
@@ -1,0 +1,83 @@
+"""Command line interface for PyZap."""
+
+import argparse
+import json
+from pathlib import Path
+
+from .core import main_loop
+
+
+def load_config(path: str) -> list:
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_config(path: str, workflows: list) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(workflows, fh, indent=2)
+
+
+def list_workflows(args: argparse.Namespace) -> None:
+    workflows = load_config(args.config)
+    for wf in workflows:
+        status = "enabled" if wf.get("enabled", True) else "disabled"
+        print(f"{wf['id']} - {status}")
+
+
+def create_workflow(args: argparse.Namespace) -> None:
+    workflows = load_config(args.config)
+    with open(args.file, "r", encoding="utf-8") as fh:
+        new_wf = json.load(fh)
+    workflows.append(new_wf)
+    save_config(args.config, workflows)
+    print(f"Added workflow {new_wf['id']}")
+
+
+def set_workflow_state(args: argparse.Namespace, enabled: bool) -> None:
+    workflows = load_config(args.config)
+    for wf in workflows:
+        if wf["id"] == args.id:
+            wf["enabled"] = enabled
+            break
+    else:
+        raise SystemExit(f"Workflow {args.id} not found")
+    save_config(args.config, workflows)
+    state = "enabled" if enabled else "disabled"
+    print(f"Workflow {args.id} {state}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="pyzap")
+    parser.add_argument("config", nargs="?", default="config.json", help="Config file path")
+    sub = parser.add_subparsers(dest="command")
+
+    sub_list = sub.add_parser("list")
+    sub_list.set_defaults(func=list_workflows)
+
+    sub_create = sub.add_parser("create")
+    sub_create.add_argument("file")
+    sub_create.set_defaults(func=create_workflow)
+
+    sub_enable = sub.add_parser("enable")
+    sub_enable.add_argument("id")
+    sub_enable.set_defaults(func=lambda a: set_workflow_state(a, True))
+
+    sub_disable = sub.add_parser("disable")
+    sub_disable.add_argument("id")
+    sub_disable.set_defaults(func=lambda a: set_workflow_state(a, False))
+
+    sub_run = sub.add_parser("run")
+    sub_run.add_argument("id")
+
+    args = parser.parse_args()
+    if args.command == "run":
+        main_loop(args.config)
+        return
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyzap/core.py
+++ b/pyzap/core.py
@@ -1,0 +1,154 @@
+"""Core workflow engine for PyZap."""
+
+import importlib
+import json
+import logging
+import os
+import threading
+import time
+from abc import ABC, abstractmethod
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any, Dict, List, Type
+
+# Plugin registries
+TRIGGERS: Dict[str, Type["BaseTrigger"]] = {}
+ACTIONS: Dict[str, Type["BaseAction"]] = {}
+
+
+class BaseTrigger(ABC):
+    """Abstract base class for triggers."""
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+
+    @abstractmethod
+    def poll(self) -> List[Dict[str, Any]]:
+        """Poll for new events and return a list of payloads."""
+        raise NotImplementedError
+
+
+class BaseAction(ABC):
+    """Abstract base class for actions."""
+
+    def __init__(self, params: Dict[str, Any]):
+        self.params = params
+
+    @abstractmethod
+    def execute(self, data: Dict[str, Any]) -> None:
+        """Execute the action on normalized data."""
+        raise NotImplementedError
+
+
+class Workflow:
+    def __init__(self, definition: Dict[str, Any]):
+        self.id = definition["id"]
+        trigger_conf = definition["trigger"]
+        trigger_cls = TRIGGERS.get(trigger_conf["type"])
+        if not trigger_cls:
+            raise ValueError(f"Unknown trigger type {trigger_conf['type']}")
+        self.trigger = trigger_cls(trigger_conf)
+        self.actions = []
+        for action_def in definition.get("actions", []):
+            action_cls = ACTIONS.get(action_def["type"])
+            if not action_cls:
+                raise ValueError(f"Unknown action type {action_def['type']}")
+            self.actions.append(action_cls(action_def.get("params", {})))
+        self.seen_ids = set()
+
+    def run(self) -> None:
+        for payload in self.trigger.poll():
+            msg_id = payload.get("id")
+            if msg_id and msg_id in self.seen_ids:
+                continue
+            if msg_id:
+                self.seen_ids.add(msg_id)
+            for action in self.actions:
+                try:
+                    from .formatter import normalize
+
+                    normalized = normalize(payload)
+                    action.execute(normalized)
+                except Exception as exc:  # pylint: disable=broad-except
+                    logging.exception("Action %s failed: %s", action, exc)
+
+
+class WorkflowEngine:
+    def __init__(self, config_path: str):
+        self.config_path = config_path
+        self.workflows: List[Workflow] = []
+        self.load_config()
+        self._stop_event = threading.Event()
+
+    def load_config(self) -> None:
+        with open(self.config_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        self.workflows = [Workflow(defn) for defn in data]
+
+    def run_all(self) -> None:
+        threads = []
+        for wf in self.workflows:
+            t = threading.Thread(target=self._run_workflow, args=(wf,), daemon=True)
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join()
+
+    def _run_workflow(self, workflow: Workflow) -> None:
+        retry = 0
+        max_retries = 3
+        while retry <= max_retries and not self._stop_event.is_set():
+            try:
+                workflow.run()
+                break
+            except Exception as exc:  # pylint: disable=broad-except
+                retry += 1
+                logging.exception("Workflow %s failed (%s). Retry %s/%s", workflow.id, exc, retry, max_retries)
+                time.sleep(1)
+        else:
+            self.notify_admin(workflow.id)
+
+    def notify_admin(self, workflow_id: str) -> None:
+        # TODO: Send email via local SMTP
+        logging.error("Workflow %s failed after retries", workflow_id)
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+
+def setup_logging(log_file: str = "pyzap.log") -> None:
+    handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3)
+    logging.basicConfig(level=logging.INFO, handlers=[handler])
+
+
+def load_plugins() -> None:
+    plugins_dir = Path(__file__).parent / "plugins"
+    for path in plugins_dir.glob("*.py"):
+        if path.name.startswith("__"):
+            continue
+        module_name = f"pyzap.plugins.{path.stem}"
+        module = importlib.import_module(module_name)
+        for attr in dir(module):
+            obj = getattr(module, attr)
+            if isinstance(obj, type) and issubclass(obj, BaseTrigger) and obj is not BaseTrigger:
+                TRIGGERS[obj.__name__.replace("Trigger", "")] = obj
+            if isinstance(obj, type) and issubclass(obj, BaseAction) and obj is not BaseAction:
+                ACTIONS[obj.__name__.replace("Action", "")] = obj
+
+
+def main_loop(config_path: str) -> None:
+    setup_logging()
+    load_plugins()
+    engine = WorkflowEngine(config_path)
+    while True:
+        try:
+            engine.run_all()
+            time.sleep(1)
+        except KeyboardInterrupt:
+            engine.stop()
+            break
+
+
+if __name__ == "__main__":
+    cfg = os.environ.get("PYZAP_CONFIG", "config.json")
+    main_loop(cfg)

--- a/pyzap/formatter.py
+++ b/pyzap/formatter.py
@@ -1,0 +1,37 @@
+"""Data formatting utilities for PyZap."""
+
+import datetime as _dt
+from typing import Any, Dict
+
+
+def clean_text(text: str) -> str:
+    """Remove line breaks and trim whitespace."""
+    return " ".join(text.split()).strip()
+
+
+def parse_date(value: str) -> _dt.datetime:
+    """Parse a date string."""
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%d-%m-%Y"):
+        try:
+            return _dt.datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    raise ValueError(f"Unknown date format: {value}")
+
+
+def parse_number(value: str) -> float:
+    return float(value)
+
+
+def map_fields(data: Dict[str, Any], mapping: Dict[str, str]) -> Dict[str, Any]:
+    return {dest: data.get(src) for src, dest in mapping.items()}
+
+
+def normalize(data: Dict[str, Any]) -> Dict[str, Any]:
+    result = {}
+    for k, v in data.items():
+        if isinstance(v, str):
+            result[k] = clean_text(v)
+        else:
+            result[k] = v
+    return result

--- a/pyzap/plugins/__init__.py
+++ b/pyzap/plugins/__init__.py
@@ -1,0 +1,3 @@
+"""PyZap plugins package."""
+
+# Plugins are discovered dynamically in pyzap.core.load_plugins

--- a/pyzap/plugins/gdrive_upload.py
+++ b/pyzap/plugins/gdrive_upload.py
@@ -1,0 +1,13 @@
+"""Google Drive upload action."""
+
+from typing import Any, Dict
+
+from ..core import BaseAction
+
+
+class GDriveUploadAction(BaseAction):
+    """Upload a file to Google Drive."""
+
+    def execute(self, data: Dict[str, Any]) -> None:
+        # TODO: Implement Google Drive upload logic
+        pass

--- a/pyzap/plugins/gmail_poll.py
+++ b/pyzap/plugins/gmail_poll.py
@@ -1,0 +1,14 @@
+"""Gmail polling trigger."""
+
+from typing import Any, Dict, List
+
+from ..core import BaseTrigger
+
+
+class GmailPollTrigger(BaseTrigger):
+    """Poll Gmail using the Gmail API."""
+
+    def poll(self) -> List[Dict[str, Any]]:
+        # TODO: Implement Gmail API polling with OAuth2
+        # Return list of message payloads with unique 'id'
+        return []

--- a/pyzap/plugins/imap_poll.py
+++ b/pyzap/plugins/imap_poll.py
@@ -1,0 +1,13 @@
+"""IMAP polling trigger."""
+
+from typing import Any, Dict, List
+
+from ..core import BaseTrigger
+
+
+class ImapPollTrigger(BaseTrigger):
+    """Poll an IMAP server for new messages."""
+
+    def poll(self) -> List[Dict[str, Any]]:
+        # TODO: Implement IMAP polling
+        return []

--- a/pyzap/plugins/sheets_append.py
+++ b/pyzap/plugins/sheets_append.py
@@ -1,0 +1,13 @@
+"""Google Sheets append action."""
+
+from typing import Any, Dict
+
+from ..core import BaseAction
+
+
+class SheetsAppendAction(BaseAction):
+    """Append data to a Google Sheet."""
+
+    def execute(self, data: Dict[str, Any]) -> None:
+        # TODO: Implement Google Sheets append logic
+        pass

--- a/pyzap/plugins/slack_notify.py
+++ b/pyzap/plugins/slack_notify.py
@@ -1,0 +1,13 @@
+"""Slack notification action."""
+
+from typing import Any, Dict
+
+from ..core import BaseAction
+
+
+class SlackNotifyAction(BaseAction):
+    """Send a notification to Slack via webhook."""
+
+    def execute(self, data: Dict[str, Any]) -> None:
+        # TODO: Implement Slack webhook notification
+        pass

--- a/pyzap/webapp.py
+++ b/pyzap/webapp.py
@@ -1,0 +1,39 @@
+"""Minimal Flask dashboard for PyZap."""
+
+from flask import Flask, jsonify, render_template_string, request
+
+from .cli import load_config, save_config
+from .core import main_loop
+
+app = Flask(__name__)
+CONFIG_PATH = "config.json"
+
+TEMPLATE = """
+<!doctype html>
+<title>PyZap Workflows</title>
+<h1>Workflows</h1>
+<ul>
+{% for wf in workflows %}
+    <li>{{ wf.id }} - {{ 'enabled' if wf.get('enabled', True) else 'disabled' }}</li>
+{% endfor %}
+</ul>
+"""
+
+
+@app.route("/")
+def index():
+    workflows = load_config(CONFIG_PATH)
+    return render_template_string(TEMPLATE, workflows=workflows)
+
+
+@app.route("/api/workflows", methods=["POST"])
+def create_workflow():
+    data = request.get_json()
+    workflows = load_config(CONFIG_PATH)
+    workflows.append(data)
+    save_config(CONFIG_PATH, workflows)
+    return jsonify({"status": "ok"})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,0 +1,6 @@
+import pytest
+
+# TODO: add action tests
+
+def test_dummy_action():
+    assert True

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,6 @@
+import pytest
+
+# TODO: add core engine tests
+
+def test_dummy_core():
+    assert True

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -1,0 +1,6 @@
+import pytest
+
+# TODO: add trigger tests
+
+def test_dummy_trigger():
+    assert True


### PR DESCRIPTION
## Summary
- set up a monolithic PyZap package
- wire up core workflow engine and plugin loader
- add CLI and minimal Flask webapp
- create placeholder plugin implementations
- provide formatting utilities and example configuration
- add tests and MkDocs scaffolding
- ignore pycache files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f972befe8832db7ab9f657bb22936