### PR TITLE
Remove leftover pickle import

### DIFF
--- a/get_gmail_token.py
+++ b/get_gmail_token.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 import os.path
-import pickle
 
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials


### PR DESCRIPTION
## Summary
- delete unused `pickle` import in `get_gmail_token.py`

## Testing
- `pytest -q`
- manual run of `get_gmail_token.main()` with stubbed Google modules to ensure `token.json` is produced

------
https://chatgpt.com/codex/tasks/task_e_6883ab29e5bc832d9540eb0c8751dd3f