### PR TITLE
Add max_results option to Gmail trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Two built-in triggers allow fetching messages from email servers:
 
 * `gmail_poll` &ndash; uses the Gmail API with an OAuth2 token. Provide a
   `token_file` path in the trigger configuration and optionally a search
-  `query`.
+  `query`. You may also specify `max_results` to limit the number of
+  messages returned.
 * `imap_poll` &ndash; connects to any IMAP server using username and password.
   Required options are `host`, `username` and `password`. Optional keys are
   `mailbox` (defaults to `INBOX`) and `search` (defaults to `UNSEEN`).

--- a/config.json
+++ b/config.json
@@ -12,6 +12,7 @@
       "trigger": {
         "type": "gmail_poll",
         "query": "from:centrella.pierino@gmail.com label:inbox",
+        "max_results": 10,
         "interval": 60
       },
       "actions": [

--- a/config.json.example
+++ b/config.json.example
@@ -12,6 +12,7 @@
       "trigger": {
         "type": "gmail_poll",
         "query": "label:inbox",
+        "max_results": 10,
         "interval": 60
       },
       "actions": [

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,9 @@ python get_gmail_token.py
 
 Follow the browser flow and place the generated `token.json` next to your `config.json` file (or reference it with the `token_file` option).
 
+The Gmail trigger also accepts a `max_results` option to control how many
+messages are fetched on each poll.
+
 Other actions like Google Drive uploads or Sheets updates expect a bearer token in the `GDRIVE_TOKEN` environment variable. Slack notifications simply need a webhook URL.
 
 ## Running the engine
@@ -47,7 +50,11 @@ Workflow definitions live in `config.json`. Below is a trimmed example showing a
   "workflows": [
     {
       "id": "example-zap",
-      "trigger": {"type": "gmail_poll", "query": "label:inbox"},
+      "trigger": {
+        "type": "gmail_poll",
+        "query": "label:inbox",
+        "max_results": 10
+      },
       "actions": [
         {"type": "g_drive_upload", "params": {"folder_id": "FOLDER_ID"}},
         {"type": "sheets_append", "params": {"sheet_id": "SHEET_ID", "range": "Sheet1!A:B"}},

--- a/pyzap/plugins/gmail_poll.py
+++ b/pyzap/plugins/gmail_poll.py
@@ -21,6 +21,7 @@ class GmailPollTrigger(BaseTrigger):
         The configuration should provide:
         - ``token_file``: path to a Gmail OAuth2 token JSON file.
         - ``query``: Gmail search query string.
+        - ``max_results`` (optional): maximum number of messages to return.
 
         Only a very small subset of the Gmail API is used here to keep the
         implementation lightweight. Errors are logged and an empty list is
@@ -29,6 +30,7 @@ class GmailPollTrigger(BaseTrigger):
 
         token_path = self.config.get("token_file", "token.json")
         query = self.config.get("query", "label:inbox")
+        max_results = int(self.config.get("max_results", 100))
 
         logging.info("Polling Gmail using %s with query '%s'", token_path, query)
         logging.debug("Loading credentials from %s", token_path)
@@ -50,7 +52,12 @@ class GmailPollTrigger(BaseTrigger):
             )
 
             logging.debug("Querying Gmail API")
-            result = service.users().messages().list(userId="me", q=query).execute()
+            result = (
+                service.users()
+                .messages()
+                .list(userId="me", q=query, maxResults=max_results)
+                .execute()
+            )
             logging.debug("Gmail API returned %s", result)
             messages = []
             for item in result.get("messages", []):

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -57,7 +57,7 @@ def _setup_google(monkeypatch, success=True):
                 return self.data
 
         class Messages:
-            def list(self, userId="me", q=None):
+            def list(self, userId="me", q=None, maxResults=None):
                 return Execute({"messages": [{"id": "1"}]})
 
             def get(self, userId="me", id=None, format="full"):


### PR DESCRIPTION
## Summary
- allow limiting Gmail polling via optional `max_results`
- document new option in README and docs
- show `max_results` usage in sample configurations
- update Gmail trigger tests for new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d2ad0958832d973eb7e7ccb176fd