### PR TITLE
Fix logging file encoding

### DIFF
--- a/pyzap/core.py
+++ b/pyzap/core.py
@@ -184,7 +184,9 @@ class WorkflowEngine:
 
 
 def setup_logging(log_file: str = "pyzap.log", *, log_level: int = logging.INFO) -> None:
-    handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3)
+    handler = RotatingFileHandler(
+        log_file, maxBytes=1_000_000, backupCount=3, encoding="utf-8"
+    )
     logging.basicConfig(
         level=log_level,
         format="%(asctime)s - %(levelname)s - %(message)s",


### PR DESCRIPTION
## Summary
- fix Unicode logging crash on Windows by opening log file with UTF-8 encoding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a9f58090832d8fd4c604a29d2bc3