### PR TITLE
Add underscore comment support in config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,10 @@ Workflow definitions live in `config.json`. Below is a trimmed example showing a
 
 Values may also reference environment variables using the `${VAR_NAME}` syntax as seen in the provided `config.json` file.
 
+Keys beginning with an underscore, for example `_comment`, are ignored when the
+configuration is loaded. This lets you annotate the JSON file with inline
+comments.
+
 With the configuration in place simply run `pyzap` as shown above and watch your automations execute.
 
 ## Archiving email

--- a/pyzap/config.py
+++ b/pyzap/config.py
@@ -18,6 +18,19 @@ except ImportError:
 ENV_VAR_PATTERN = re.compile(r"\$\{(.+?)\}")
 
 
+def _strip_comments(data: Any) -> Any:
+    """Recursively remove keys starting with an underscore."""
+    if isinstance(data, dict):
+        return {
+            k: _strip_comments(v)
+            for k, v in data.items()
+            if not k.startswith("_")
+        }
+    if isinstance(data, list):
+        return [_strip_comments(i) for i in data]
+    return data
+
+
 def _substitute_env_vars(data: Any) -> Any:
     """Recursively substitute environment variables in config data."""
     if isinstance(data, dict):
@@ -43,7 +56,8 @@ def load_config(path: str) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
     """Load configuration from JSON file with environment variable substitution."""
     with open(path, "r", encoding="utf-8") as fh:
         raw_config = json.load(fh)
-    return _substitute_env_vars(raw_config)
+    cleaned = _strip_comments(raw_config)
+    return _substitute_env_vars(cleaned)
 
 
 def save_config(path: str, config: Union[Dict[str, Any], List[Dict[str, Any]]]) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,37 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from pyzap.config import load_config
+
+
+def test_load_config_strips_comment_keys(tmp_path):
+    data = {
+        "_comment": "top",
+        "value": 1,
+        "nested": {"x": 2, "_note": "n"},
+        "items": [{"a": 1, "_b": 2}, 3],
+    }
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps(data))
+
+    cfg = load_config(str(path))
+    assert "_comment" not in cfg
+    assert "value" in cfg and cfg["value"] == 1
+    assert "_note" not in cfg["nested"]
+    assert cfg["nested"]["x"] == 2
+    assert cfg["items"][0] == {"a": 1}
+    assert cfg["items"][1] == 3
+
+
+def test_load_config_env_vars_and_comments(monkeypatch, tmp_path):
+    monkeypatch.setenv("VAL", "42")
+    data = {"num": "${VAL}", "_c": "x"}
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps(data))
+    cfg = load_config(str(path))
+    assert cfg == {"num": "42"}


### PR DESCRIPTION
## Summary
- ignore keys that begin with `_` in configuration files
- document the new comment feature
- test comment stripping and env var substitution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d23e8d08832daa8a8bf828c539bc