### PR TITLE
Improve ExcelAppend error handling

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Welcome to the PyZap documentation. PyZap is a lightweight workflow automation e
    ```
 2. Install the required libraries:
    ```bash
-   pip install flask google-api-python-client google-auth google-auth-oauthlib python-dotenv
+   pip install -r requirements.txt
    ```
 
 ## Obtaining API credentials

--- a/pyzap/plugins/excel_append.py
+++ b/pyzap/plugins/excel_append.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from openpyxl import load_workbook
+
 
 from ..core import BaseAction
 
@@ -13,6 +13,14 @@ class ExcelAppendAction(BaseAction):
     """Append data to an Excel workbook."""
 
     def execute(self, data: Dict[str, Any]) -> None:
+        try:
+            from openpyxl import load_workbook  # type: ignore
+        except ImportError as exc:  # pragma: no cover - dependency missing
+            raise RuntimeError(
+                "excel_append action requires the 'openpyxl' package. "
+                "Install it with 'pip install openpyxl'."
+            ) from exc
+
         file_path = self.params.get("file")
         sheet_name = self.params.get("sheet")
         fields: List[str] = self.params.get("fields", [])

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -311,3 +311,17 @@ def test_excel_append(monkeypatch, tmp_path):
     wb2 = openpyxl.load_workbook(file_path)
     row = [cell.value for cell in wb2.active[1]]
     assert row == [1, 2]
+
+
+def test_excel_append_missing_dependency(monkeypatch, tmp_path):
+    """excel_append should error gracefully when openpyxl is unavailable."""
+    import importlib, sys
+
+    monkeypatch.delitem(sys.modules, 'openpyxl', raising=False)
+    module = importlib.import_module('pyzap.plugins.excel_append')
+    module = importlib.reload(module)
+    ExcelAppendAction = module.ExcelAppendAction
+
+    action = ExcelAppendAction({'file': str(tmp_path / 'book.xlsx')})
+    with pytest.raises(RuntimeError):
+        action.execute({'values': [1, 2]})


### PR DESCRIPTION
## Summary
- handle missing `openpyxl` dependency inside `excel_append`
- document using `requirements.txt` in the docs
- test behavior when `openpyxl` is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d923e288832da6700fce1cbd1227