### PR TITLE
Add filters to gmail archive and skip empty storage path in Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ Two built-in triggers allow fetching messages from email servers:
 Two archive actions download an email and its attachments then return metadata
 that can be appended to a spreadsheet:
 
-* `gmail_archive` &ndash; stores a Gmail message in a subfolder on Google Drive
-  or under a local directory. Provide a `token_file` along with either
-  `drive_folder_id` or `local_dir`.
+* `gmail_archive` &ndash; stores a Gmail message and/or its attachments in a
+  subfolder on Google Drive or under a local directory. Provide a `token_file`
+  along with either `drive_folder_id` or `local_dir`. Optional parameters let
+  you skip saving the message body with `save_message` (defaults to `true`) and
+  filter attachments by extension using `attachment_types` (e.g. `[".pdf"]`).
 * `imap_archive` &ndash; similar functionality for standard IMAP servers. It
   requires `host`, `username` and `password` and the same destination options as
   `gmail_archive`.

--- a/config.json
+++ b/config.json
@@ -20,7 +20,14 @@
         "interval": 60
       },
       "actions": [
-        {"type": "gmail_archive", "params": {"local_dir": "./archive"}},
+        {
+          "type": "gmail_archive",
+          "params": {
+            "local_dir": "./archive",
+            "attachment_types": [".pdf"],
+            "save_message": false
+          }
+        },
         {"type": "excel_append", "params": {"file": "log.xlsx"}}
       ]
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,14 @@ metadata into spreadsheet appenders:
   "id": "archive-example",
   "trigger": {"type": "gmail_poll"},
   "actions": [
-    {"type": "gmail_archive", "params": {"local_dir": "./archive"}},
+    {
+      "type": "gmail_archive",
+      "params": {
+        "local_dir": "./archive",
+        "attachment_types": [".pdf"],
+        "save_message": false
+      }
+    },
     {"type": "excel_append", "params": {"file": "log.xlsx"}}
   ]
 }

--- a/pyzap/plugins/excel_append.py
+++ b/pyzap/plugins/excel_append.py
@@ -32,17 +32,21 @@ class ExcelAppendAction(BaseAction):
 
         if "values" in data:
             values = data["values"]
+            field_names = [str(i) for i in range(len(values))]
         else:
             if not fields:
                 fields = list(data.keys())
+            field_names = fields
             values = [data.get(f) for f in fields]
 
-        def _convert(value: Any) -> Any:
+        def _convert(value: Any, name: str) -> Any:
+            if name == "storage_path" and not value:
+                return None
             if isinstance(value, (list, tuple)):
                 return ", ".join(str(v) for v in value)
             if isinstance(value, dict):
                 return json.dumps(value, ensure_ascii=False)
             return value
 
-        ws.append([_convert(v) for v in values])
+        ws.append([_convert(v, n) for v, n in zip(values, field_names)])
         wb.save(file_path)


### PR DESCRIPTION
## Summary
- allow `gmail_archive` to skip message body and filter attachment types
- avoid creating archive subfolder when not saving anything
- make `excel_append` omit storage_path value if folder was not created
- document new parameters
- update example configuration
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688520a69090832d8639e9b5b7522a8c