### PR TITLE
Fix gmail link downloads without attachments

### DIFF
--- a/pyzap/plugins/gmail_archive.py
+++ b/pyzap/plugins/gmail_archive.py
@@ -120,9 +120,10 @@ class GmailArchiveAction(BaseAction):
                     attachments.append(filename)
 
         message_text = snippet
-        if save_attachments and download_links:
-            for txt in self._collect_text(msg.get("payload", {})):
-                message_text += "\n" + txt
+        for txt in self._collect_text(msg.get("payload", {})):
+            message_text += "\n" + txt
+
+        if download_links:
             for url in re.findall(r"https?://\S+", message_text):
                 parsed = urlparse(url)
                 name = os.path.basename(parsed.path)


### PR DESCRIPTION
## Summary
- allow link downloads even when attachments are not saved
- scan entire message body for links
- test downloading links without attachments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852fe51af4832d8028b29ff74741ff