### PR TITLE
Support multiple Gmail accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Two built-in triggers allow fetching messages from email servers:
 * `gmail_poll` &ndash; uses the Gmail API with an OAuth2 token. Provide a
   `token_file` path in the trigger configuration and optionally a search
   `query`. You may also specify `max_results` to limit the number of
-  messages returned.
+  messages returned. To monitor multiple mailboxes in one workflow use an
+  `accounts` list where each entry contains its own `token_file` and `query`.
 * `imap_poll` &ndash; connects to any IMAP server using username and password.
   Required options are `host`, `username` and `password`. Optional keys are
   `mailbox` (defaults to `INBOX`) and `search` (defaults to `UNSEEN`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,8 @@ Follow the browser flow and place the generated `token.json` next to your `confi
 
 The Gmail trigger also accepts a `max_results` option to control how many
 messages are fetched on each poll.
+You can monitor multiple Gmail accounts in one workflow by providing an
+`accounts` list containing per-account `token_file` and `query` values.
 
 Other actions like Google Drive uploads or Sheets updates expect a bearer token in the `GDRIVE_TOKEN` environment variable. Slack notifications simply need a webhook URL.
 

--- a/pyzap/plugins/gmail_archive.py
+++ b/pyzap/plugins/gmail_archive.py
@@ -100,7 +100,7 @@ class GmailArchiveAction(BaseAction):
         return data["id"]
 
     def execute(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        token_file = self.params.get("token_file", "token.json")
+        token_file = self.params.get("token_file") or data.get("token_file", "token.json")
         drive_parent = self.params.get("drive_folder_id")
         local_dir = self.params.get("local_dir")
         token = self.params.get("token") or os.environ.get("GDRIVE_TOKEN")

--- a/pyzap/plugins/gmail_poll.py
+++ b/pyzap/plugins/gmail_poll.py
@@ -15,81 +15,105 @@ from ..core import BaseTrigger
 class GmailPollTrigger(BaseTrigger):
     """Poll Gmail using the Gmail API."""
 
+    def _poll_account(
+        self, token_path: str, query: str, max_results: int
+    ) -> List[Dict[str, Any]]:
+        """Poll a single Gmail account and return messages."""
+
+        logging.info("Polling Gmail using %s with query '%s'", token_path, query)
+        logging.debug("Loading credentials from %s", token_path)
+
+        creds = Credentials.from_authorized_user_file(
+            token_path,
+            ["https://www.googleapis.com/auth/gmail.readonly"],
+        )
+        if creds.expired and creds.refresh_token:
+            logging.debug("Refreshing Gmail token")
+            creds.refresh(Request())  # type: ignore[attr-defined]
+        logging.debug("Building Gmail service")
+        service = build(
+            "gmail",
+            "v1",
+            credentials=creds,
+            cache_discovery=False,
+        )
+
+        logging.debug("Querying Gmail API")
+        result = (
+            service.users()
+            .messages()
+            .list(userId="me", q=query, maxResults=max_results)
+            .execute()
+        )
+        logging.debug("Gmail API returned %s", result)
+        messages: List[Dict[str, Any]] = []
+        for item in result.get("messages", []):
+            msg_id = item["id"]
+            msg = (
+                service.users()
+                .messages()
+                .get(userId="me", id=msg_id, format="full")
+                .execute()
+            )
+            msg["id"] = msg_id
+            msg["token_file"] = token_path
+            messages.append(msg)
+
+            headers = msg.get("payload", {}).get("headers", [])
+            sender = ""
+            subject = ""
+            for header in headers:
+                name = header.get("name", "").lower()
+                if name == "from":
+                    sender = header.get("value", "")
+                elif name == "subject":
+                    subject = header.get("value", "")
+                if sender and subject:
+                    break
+            logging.debug(
+                "Fetched Gmail message %s from %s with subject %s",
+                msg_id,
+                sender,
+                subject,
+            )
+        return messages
+
     def poll(self) -> List[Dict[str, Any]]:
         """Return unread messages matching the configured query.
 
-        The configuration should provide:
+        Configuration options:
         - ``token_file``: path to a Gmail OAuth2 token JSON file.
         - ``query``: Gmail search query string.
         - ``max_results`` (optional): maximum number of messages to return.
+        - ``accounts`` (optional): list of account-specific dictionaries with the
+          same keys as above to poll multiple mailboxes.
 
         Only a very small subset of the Gmail API is used here to keep the
         implementation lightweight. Errors are logged and an empty list is
         returned if polling fails.
         """
-
-        token_path = self.config.get("token_file", "token.json")
-        query = self.config.get("query", "label:inbox")
-        max_results = int(self.config.get("max_results", 100))
-
-        logging.info("Polling Gmail using %s with query '%s'", token_path, query)
-        logging.debug("Loading credentials from %s", token_path)
-
         try:
-            creds = Credentials.from_authorized_user_file(
-                token_path,
-                ["https://www.googleapis.com/auth/gmail.readonly"],
-            )
-            if creds.expired and creds.refresh_token:
-                logging.debug("Refreshing Gmail token")
-                creds.refresh(Request())  # type: ignore[attr-defined]
-            logging.debug("Building Gmail service")
-            service = build(
-                "gmail",
-                "v1",
-                credentials=creds,
-                cache_discovery=False,
-            )
+            account_cfgs = self.config.get("accounts")
+            if account_cfgs:
+                results: List[Dict[str, Any]] = []
+                for acc in account_cfgs:
+                    token_path = acc.get(
+                        "token_file", self.config.get("token_file", "token.json")
+                    )
+                    query = acc.get("query", self.config.get("query", "label:inbox"))
+                    max_results = int(
+                        acc.get("max_results", self.config.get("max_results", 100))
+                    )
+                    results.extend(self._poll_account(token_path, query, max_results))
+                logging.info("Gmail polling returned %d messages", len(results))
+                return results
 
-            logging.debug("Querying Gmail API")
-            result = (
-                service.users()
-                .messages()
-                .list(userId="me", q=query, maxResults=max_results)
-                .execute()
-            )
-            logging.debug("Gmail API returned %s", result)
-            messages = []
-            for item in result.get("messages", []):
-                msg_id = item["id"]
-                msg = (
-                    service.users()
-                    .messages()
-                    .get(userId="me", id=msg_id, format="full")
-                    .execute()
-                )
-                msg["id"] = msg_id
-                messages.append(msg)
-
-                headers = msg.get("payload", {}).get("headers", [])
-                sender = ""
-                subject = ""
-                for header in headers:
-                    name = header.get("name", "").lower()
-                    if name == "from":
-                        sender = header.get("value", "")
-                    elif name == "subject":
-                        subject = header.get("value", "")
-                    if sender and subject:
-                        break
-                logging.debug(
-                    "Fetched Gmail message %s from %s with subject %s",
-                    msg_id,
-                    sender,
-                    subject,
-                )
-            logging.info("Gmail polling returned %d messages", len(messages))
-            return messages
+            token_path = self.config.get("token_file", "token.json")
+            query = self.config.get("query", "label:inbox")
+            max_results = int(self.config.get("max_results", 100))
+            results = self._poll_account(token_path, query, max_results)
+            logging.info("Gmail polling returned %d messages", len(results))
+            return results
         except Exception as exc:  # pylint: disable=broad-except
             logging.exception("Gmail polling failed: %s", exc)
             return []

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -484,6 +484,20 @@ def test_gmail_archive_links_no_attachments(monkeypatch, tmp_path):
     assert result['attachments'] == ['file.pdf']
 
 
+def test_gmail_archive_token_from_message(monkeypatch, tmp_path):
+    """token_file may be supplied in the message payload."""
+    _setup_gmail(monkeypatch)
+    import importlib
+    module = importlib.import_module('pyzap.plugins.gmail_archive')
+    module = importlib.reload(module)
+    action_cls = module.GmailArchiveAction
+    action = action_cls({'local_dir': str(tmp_path)})
+    result = action.execute({'id': '123', 'token_file': 'token.json'})
+    folder = tmp_path / '123'
+    assert folder.exists()
+    assert result['sender'] == 'f'
+
+
 def test_gmail_archive_html_link_header(monkeypatch, tmp_path):
     _setup_gmail_html(monkeypatch)
     import importlib

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -113,6 +113,27 @@ def test_gmail_poll_error(monkeypatch):
     assert trigger.poll() == []
 
 
+def test_gmail_poll_multiple(monkeypatch):
+    """Polling multiple Gmail accounts should merge results."""
+    _setup_google(monkeypatch, success=True)
+    import importlib
+    module = importlib.import_module("pyzap.plugins.gmail_poll")
+    module = importlib.reload(module)
+    GmailPollTrigger = module.GmailPollTrigger
+
+    trigger = GmailPollTrigger(
+        {
+            "accounts": [
+                {"token_file": "a.json", "query": "q1"},
+                {"token_file": "b.json", "query": "q2"},
+            ]
+        }
+    )
+    msgs = trigger.poll()
+    assert len(msgs) == 2
+    assert {m["token_file"] for m in msgs} == {"a.json", "b.json"}
+
+
 def test_imap_poll(monkeypatch):
     from pyzap.plugins.imap_poll import ImapPollTrigger
 


### PR DESCRIPTION
## Summary
- allow Gmail polling trigger to handle multiple accounts via `accounts` option
- let gmail_archive read `token_file` from each message
- document multi-account feature in README and docs
- add regression tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855aab3024832db4137f759fc47389