### PR TITLE
Add Excel polling trigger

### DIFF
--- a/pyzap/plugins/excel_poll.py
+++ b/pyzap/plugins/excel_poll.py
@@ -1,0 +1,76 @@
+"""Excel polling trigger."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from ..core import BaseTrigger
+
+
+class ExcelPollTrigger(BaseTrigger):
+    """Poll an Excel workbook for newly appended rows."""
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.state_file = self.config.get("state_file")
+        self.start_row = int(self.config.get("start_row", 2))
+        self.last_row = self.start_row - 1
+        if self.state_file and os.path.exists(self.state_file):
+            try:
+                with open(self.state_file, "r", encoding="utf-8") as fh:
+                    self.last_row = int(fh.read().strip() or self.last_row)
+            except Exception:
+                pass
+
+    def _save_state(self) -> None:
+        if not self.state_file:
+            return
+        try:
+            with open(self.state_file, "w", encoding="utf-8") as fh:
+                fh.write(str(self.last_row))
+        except Exception:
+            pass
+
+    def poll(self) -> List[Dict[str, Any]]:
+        try:
+            from openpyxl import load_workbook  # type: ignore
+        except ImportError as exc:  # pragma: no cover - dependency missing
+            raise RuntimeError(
+                "excel_poll trigger requires the 'openpyxl' package. Install it with 'pip install openpyxl'."
+            ) from exc
+
+        file_path = self.config.get("file")
+        sheet_name = self.config.get("sheet")
+        filters: Dict[Any, Any] = self.config.get("filters", {})
+        if not file_path:
+            raise ValueError("file parameter required")
+
+        wb = load_workbook(file_path)
+        ws = wb[sheet_name] if sheet_name else wb.active
+
+        max_row = getattr(ws, "max_row", None)
+        if max_row is None:
+            rows_attr = getattr(ws, "rows", [])
+            try:
+                max_row = len(list(rows_attr))
+            except TypeError:
+                max_row = len(rows_attr)
+
+        results: List[Dict[str, Any]] = []
+        for row_idx in range(self.last_row + 1, max_row + 1):
+            cells = ws[row_idx]
+            values = [getattr(c, "value", None) for c in cells]
+            match = True
+            for col, expected in filters.items():
+                idx = int(col) - 1
+                val = values[idx] if idx < len(values) else None
+                if val != expected:
+                    match = False
+                    break
+            if match:
+                results.append({"id": str(row_idx), "values": values})
+
+        self.last_row = max_row
+        self._save_state()
+        return results

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -1,6 +1,8 @@
 import sys
 import types
 import imaplib
+import os
+import pytest
 from pathlib import Path
 
 # Ensure project root on path for test imports
@@ -90,6 +92,51 @@ def _setup_google(monkeypatch, success=True):
         monkeypatch.setitem(sys.modules, name, mod)
 
 
+def _setup_openpyxl(monkeypatch):
+    """Create a fake openpyxl module for Excel tests."""
+    import types
+    import json
+
+    openpyxl = types.ModuleType("openpyxl")
+
+    class DummyCell:
+        def __init__(self, value):
+            self.value = value
+
+    class Worksheet:
+        def __init__(self):
+            self.rows = []
+
+        def append(self, values):
+            self.rows.append(list(values))
+
+        def __getitem__(self, idx):
+            row = self.rows[idx - 1]
+            return [DummyCell(v) for v in row]
+
+    class Workbook:
+        def __init__(self):
+            self.active = Worksheet()
+
+        def save(self, path):
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(self.active.rows, fh)
+
+        def __getitem__(self, name):
+            return self.active
+
+    def load_workbook(path):
+        wb = Workbook()
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as fh:
+                wb.active.rows = json.load(fh)
+        return wb
+
+    openpyxl.Workbook = Workbook
+    openpyxl.load_workbook = load_workbook
+    monkeypatch.setitem(sys.modules, "openpyxl", openpyxl)
+
+
 def test_gmail_poll_success(monkeypatch):
     _setup_google(monkeypatch, success=True)
     import importlib
@@ -170,3 +217,70 @@ def test_imap_poll_missing_config():
 
     trigger = ImapPollTrigger({})
     assert trigger.poll() == []
+
+
+def test_excel_poll(monkeypatch, tmp_path):
+    _setup_openpyxl(monkeypatch)
+    import importlib
+    openpyxl = importlib.import_module("openpyxl")
+    ExcelPollTrigger = importlib.import_module(
+        "pyzap.plugins.excel_poll"
+    ).ExcelPollTrigger
+
+    file_path = tmp_path / "book.xlsx"
+    state = tmp_path / "state.txt"
+    wb = openpyxl.Workbook()
+    wb.active.append(["a", "b"])
+    wb.save(file_path)
+
+    trigger = ExcelPollTrigger({"file": str(file_path), "state_file": str(state)})
+    assert trigger.poll() == []
+
+    wb = openpyxl.load_workbook(file_path)
+    wb.active.append([1, 2])
+    wb.save(file_path)
+
+    rows = trigger.poll()
+    assert rows == [{"id": "2", "values": [1, 2]}]
+    assert trigger.poll() == []
+
+
+def test_excel_poll_filter(monkeypatch, tmp_path):
+    _setup_openpyxl(monkeypatch)
+    import importlib
+    openpyxl = importlib.import_module("openpyxl")
+    ExcelPollTrigger = importlib.import_module(
+        "pyzap.plugins.excel_poll"
+    ).ExcelPollTrigger
+
+    file_path = tmp_path / "book.xlsx"
+    wb = openpyxl.Workbook()
+    wb.active.append(["h1", "h2"])
+    wb.active.append([1, "keep"])
+    wb.active.append([2, "skip"])
+    wb.save(file_path)
+
+    trigger = ExcelPollTrigger({"file": str(file_path), "filters": {2: "keep"}})
+    rows = trigger.poll()
+    assert rows == [{"id": "2", "values": [1, "keep"]}]
+
+
+def test_excel_poll_missing_dependency(monkeypatch):
+    import importlib
+    import builtins
+    monkeypatch.delitem(sys.modules, "openpyxl", raising=False)
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "openpyxl" or name.startswith("openpyxl."):
+            raise ImportError("No module named openpyxl")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    module = importlib.import_module("pyzap.plugins.excel_poll")
+    module = importlib.reload(module)
+    ExcelPollTrigger = module.ExcelPollTrigger
+
+    trigger = ExcelPollTrigger({"file": "book.xlsx"})
+    with pytest.raises(RuntimeError):
+        trigger.poll()


### PR DESCRIPTION
## Summary
- add `ExcelPollTrigger` plugin to monitor Excel files for new rows
- test the Excel polling trigger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688775b64260832db952ce496ad32033