### PR TITLE
Add Excel polling enhancements and file actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ that can be appended to a spreadsheet:
 The resulting metadata dictionary can be passed to `sheets_append` or the new
 `excel_append` action which writes rows to a local `.xlsx` workbook.
 
+## Excel triggers and file actions
+
+PyZap includes lightweight triggers for monitoring Excel files:
+
+* `excel_poll` &ndash; detects newly added rows.
+* `excel_cell` &ndash; fires when selected columns change.
+* `excel_file` &ndash; fires when the workbook file is modified.
+* `excel_attachments` &ndash; like `excel_poll` but also parses a column
+  containing comma separated file references.
+
+A set of utility actions can then process the data:
+
+* `excel_upsert` &ndash; update an existing row or append a new one.
+* `file_create` &ndash; write payload data to a text, JSON or CSV file.
+* `file_download` and `file_rename` &ndash; download attachments and rename
+  them according to a template.
+* `email_send` &ndash; send a simple notification email via SMTP.
+* `sql_store` &ndash; store the payload as JSON in a SQLite database.
+
 ## Logging
 
 Runtime logs are written to `pyzap.log`. Use the `--log-level` option of

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,15 @@ You can monitor multiple Gmail accounts in one workflow by providing an
 
 Other actions like Google Drive uploads or Sheets updates expect a bearer token in the `GDRIVE_TOKEN` environment variable. Slack notifications simply need a webhook URL.
 
+## Excel workflows
+
+PyZap can also monitor local Excel workbooks using several triggers. `excel_poll`
+detects new rows, `excel_cell` watches for changes in selected columns and
+`excel_file` fires whenever the file is modified. `excel_attachments` behaves
+like `excel_poll` but parses a column containing comma separated file paths.
+Related actions such as `excel_upsert`, `file_create`, `file_download` and
+`file_rename` help process the extracted data.
+
 ## Running the engine
 
 Use the CLI to start the workflow engine:

--- a/pyzap/plugins/email_send.py
+++ b/pyzap/plugins/email_send.py
@@ -1,0 +1,30 @@
+"""Send a simple email message."""
+
+from __future__ import annotations
+
+import smtplib
+from email.message import EmailMessage
+from typing import Any, Dict
+
+from ..core import BaseAction
+
+
+class EmailSendAction(BaseAction):
+    """Send email using the local SMTP server."""
+
+    def execute(self, data: Dict[str, Any]) -> None:
+        to_addr = self.params.get("to") or data.get("to")
+        subject = self.params.get("subject", "PyZap Notification")
+        body = data.get("text") or data.get("body") or ""
+        from_addr = self.params.get("from_addr", "noreply@example.com")
+        host = self.params.get("host", "localhost")
+        port = int(self.params.get("port", 25))
+        if not to_addr:
+            raise ValueError("recipient address required")
+        msg = EmailMessage()
+        msg["Subject"] = subject
+        msg["From"] = from_addr
+        msg["To"] = to_addr
+        msg.set_content(body)
+        with smtplib.SMTP(host, port) as smtp:
+            smtp.send_message(msg)

--- a/pyzap/plugins/excel_poll.py
+++ b/pyzap/plugins/excel_poll.py
@@ -1,0 +1,190 @@
+"""Excel polling trigger."""
+
+from __future__ import annotations
+
+import os
+import json
+from typing import Any, Dict, List
+
+from ..core import BaseTrigger
+
+
+__all__ = [
+    "ExcelPollTrigger",
+    "ExcelCellTrigger",
+    "ExcelFileTrigger",
+    "ExcelAttachmentsTrigger",
+]
+
+
+class ExcelPollTrigger(BaseTrigger):
+    """Poll an Excel workbook for newly appended rows."""
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.state_file = self.config.get("state_file")
+        self.start_row = int(self.config.get("start_row", 2))
+        self.last_row = self.start_row - 1
+        if self.state_file and os.path.exists(self.state_file):
+            try:
+                with open(self.state_file, "r", encoding="utf-8") as fh:
+                    self.last_row = int(fh.read().strip() or self.last_row)
+            except Exception:
+                pass
+
+    def _save_state(self) -> None:
+        if not self.state_file:
+            return
+        try:
+            with open(self.state_file, "w", encoding="utf-8") as fh:
+                fh.write(str(self.last_row))
+        except Exception:
+            pass
+
+    def poll(self) -> List[Dict[str, Any]]:
+        try:
+            from openpyxl import load_workbook  # type: ignore
+        except ImportError as exc:  # pragma: no cover - dependency missing
+            raise RuntimeError(
+                "excel_poll trigger requires the 'openpyxl' package. Install it with 'pip install openpyxl'."
+            ) from exc
+
+        file_path = self.config.get("file")
+        sheet_name = self.config.get("sheet")
+        filters: Dict[Any, Any] = self.config.get("filters", {})
+        if not file_path:
+            raise ValueError("file parameter required")
+
+        wb = load_workbook(file_path)
+        ws = wb[sheet_name] if sheet_name else wb.active
+
+        max_row = getattr(ws, "max_row", None)
+        if max_row is None:
+            rows_attr = getattr(ws, "rows", [])
+            try:
+                max_row = len(list(rows_attr))
+            except TypeError:
+                max_row = len(rows_attr)
+
+        results: List[Dict[str, Any]] = []
+        for row_idx in range(self.last_row + 1, max_row + 1):
+            cells = ws[row_idx]
+            values = [getattr(c, "value", None) for c in cells]
+            match = True
+            for col, expected in filters.items():
+                idx = int(col) - 1
+                val = values[idx] if idx < len(values) else None
+                if val != expected:
+                    match = False
+                    break
+            if match:
+                results.append({"id": str(row_idx), "values": values})
+
+        self.last_row = max_row
+        self._save_state()
+        return results
+
+
+class ExcelAttachmentsTrigger(ExcelPollTrigger):
+    """Extend :class:`ExcelPollTrigger` parsing an attachments column."""
+
+    def poll(self) -> List[Dict[str, Any]]:
+        rows = super().poll()
+        col = int(self.config.get("attachments_col", 1)) - 1
+        for row in rows:
+            raw = row["values"][col] if col < len(row["values"]) else ""
+            attachments: List[str] = []
+            if isinstance(raw, str):
+                attachments = [a.strip() for a in raw.split(",") if a.strip()]
+            row["attachments"] = attachments
+        return rows
+
+
+class ExcelCellTrigger(BaseTrigger):
+    """Trigger when values in selected columns change."""
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.state_file = self.config.get("state_file")
+        cols = self.config.get("columns", [])
+        self.columns = [int(c) for c in cols]
+        self.state: Dict[str, Dict[str, Any]] = {}
+        if self.state_file and os.path.exists(self.state_file):
+            try:
+                with open(self.state_file, "r", encoding="utf-8") as fh:
+                    self.state = json.load(fh)
+            except Exception:
+                self.state = {}
+            self._initialized = True
+        else:
+            self._initialized = False
+
+    def _save_state(self) -> None:
+        if not self.state_file:
+            return
+        try:
+            with open(self.state_file, "w", encoding="utf-8") as fh:
+                json.dump(self.state, fh)
+        except Exception:
+            pass
+
+    def poll(self) -> List[Dict[str, Any]]:
+        try:
+            from openpyxl import load_workbook  # type: ignore
+        except ImportError as exc:  # pragma: no cover - dependency missing
+            raise RuntimeError(
+                "excel_cell trigger requires the 'openpyxl' package. Install it with 'pip install openpyxl'."
+            ) from exc
+
+        file_path = self.config.get("file")
+        sheet_name = self.config.get("sheet")
+        if not file_path:
+            raise ValueError("file parameter required")
+
+        wb = load_workbook(file_path)
+        ws = wb[sheet_name] if sheet_name else wb.active
+
+        max_row = getattr(ws, "max_row", len(getattr(ws, "rows", [])))
+        results: List[Dict[str, Any]] = []
+        for row_idx in range(1, max_row + 1):
+            cells = ws[row_idx]
+            values = [getattr(c, "value", None) for c in cells]
+            row_state = self.state.get(str(row_idx), {})
+            changed: Dict[str, Any] = {}
+            for col in self.columns:
+                idx = col - 1
+                val = values[idx] if idx < len(values) else None
+                if row_state.get(str(col)) != val:
+                    changed[str(col)] = val
+                    row_state[str(col)] = val
+            if self._initialized and changed:
+                results.append({"id": f"{row_idx}", "values": values, "changes": changed})
+            if row_state:
+                self.state[str(row_idx)] = row_state
+
+        self._save_state()
+        self._initialized = True
+        return results
+
+
+class ExcelFileTrigger(BaseTrigger):
+    """Trigger when the Excel file modification time changes."""
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.last_mtime: float | None = None
+
+    def poll(self) -> List[Dict[str, Any]]:
+        file_path = self.config.get("file")
+        if not file_path:
+            raise ValueError("file parameter required")
+        if not os.path.exists(file_path):
+            return []
+        mtime = os.path.getmtime(file_path)
+        if self.last_mtime is None:
+            self.last_mtime = mtime
+            return []
+        if mtime > self.last_mtime:
+            self.last_mtime = mtime
+            return [{"id": str(int(mtime)), "file": file_path}]
+        return []

--- a/pyzap/plugins/excel_upsert.py
+++ b/pyzap/plugins/excel_upsert.py
@@ -1,0 +1,57 @@
+"""Upsert rows in an Excel file."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+from ..core import BaseAction
+
+
+class ExcelUpsertAction(BaseAction):
+    """Insert or update rows in an Excel workbook."""
+
+    def execute(self, data: Dict[str, Any]) -> None:
+        try:
+            from openpyxl import load_workbook  # type: ignore
+        except ImportError as exc:  # pragma: no cover - dependency missing
+            raise RuntimeError(
+                "excel_upsert action requires the 'openpyxl' package. Install it with 'pip install openpyxl'."
+            ) from exc
+
+        file_path = self.params.get("file")
+        sheet_name = self.params.get("sheet")
+        key_col = int(self.params.get("key_col", 1))
+        fields: List[str] = self.params.get("fields", [])
+        if not file_path:
+            raise ValueError("file parameter required")
+        wb = load_workbook(file_path)
+        ws = wb[sheet_name] if sheet_name else wb.active
+
+        if "values" in data:
+            values = data["values"]
+        else:
+            if not fields:
+                fields = list(data.keys())
+            values = [data.get(f) for f in fields]
+
+        key = values[key_col - 1] if key_col - 1 < len(values) else None
+        target_row = None
+        max_row = getattr(ws, "max_row", len(getattr(ws, "rows", [])))
+        for idx in range(1, max_row + 1):
+            row = ws[idx]
+            if len(row) >= key_col and getattr(row[key_col - 1], "value", None) == key:
+                target_row = idx
+                break
+
+        if target_row is None:
+            ws.append(values)
+        else:
+            row = ws.rows[target_row - 1]
+            for idx, val in enumerate(values):
+                if idx < len(row):
+                    row[idx] = val
+                else:
+                    row.append(val)
+
+        wb.save(file_path)

--- a/pyzap/plugins/file_create.py
+++ b/pyzap/plugins/file_create.py
@@ -1,0 +1,32 @@
+"""Create a file from the payload."""
+
+from __future__ import annotations
+
+import json
+import csv
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..core import BaseAction
+
+
+class FileCreateAction(BaseAction):
+    """Write data to a file in various formats."""
+
+    def execute(self, data: Dict[str, Any]) -> None:
+        path = self.params.get("path")
+        fmt = str(self.params.get("format", "txt")).lower()
+        if not path:
+            raise ValueError("path required")
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if fmt == "json":
+            p.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+        elif fmt == "csv":
+            values = data.get("values") or list(data.values())
+            with p.open("w", newline="", encoding="utf-8") as fh:
+                writer = csv.writer(fh)
+                writer.writerow(values)
+        else:
+            text = str(data.get("text") or data)
+            p.write_text(text, encoding="utf-8")

--- a/pyzap/plugins/file_download.py
+++ b/pyzap/plugins/file_download.py
@@ -1,0 +1,35 @@
+"""Download or copy files from provided references."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from urllib import request
+from urllib.parse import urlparse
+from typing import Any, Dict, List
+
+from ..core import BaseAction
+
+
+class DownloadFilesAction(BaseAction):
+    """Download attachments specified in ``attachments`` list."""
+
+    def execute(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        dest = self.params.get("dest")
+        refs: List[str] = data.get("attachments", [])
+        if not dest or not refs:
+            return data
+        Path(dest).mkdir(parents=True, exist_ok=True)
+        saved: List[str] = []
+        for ref in refs:
+            name = os.path.basename(urlparse(ref).path)
+            target = Path(dest) / name
+            if ref.startswith("http://") or ref.startswith("https://"):
+                with request.urlopen(ref) as resp:
+                    target.write_bytes(resp.read())
+            else:
+                shutil.copy(ref, target)
+            saved.append(str(target))
+        data["files"] = saved
+        return data

--- a/pyzap/plugins/file_rename.py
+++ b/pyzap/plugins/file_rename.py
@@ -1,0 +1,28 @@
+"""Rename downloaded files using a template."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..core import BaseAction
+
+
+class RenameFilesAction(BaseAction):
+    """Rename files with a format pattern."""
+
+    def execute(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        files: List[str] = data.get("files", [])
+        pattern = self.params.get("pattern", "{name}{ext}")
+        if not files:
+            return data
+        renamed: List[str] = []
+        for path in files:
+            p = Path(path)
+            new_name = pattern.format(name=p.stem, ext=p.suffix, **data)
+            target = p.with_name(new_name)
+            p.rename(target)
+            renamed.append(str(target))
+        data["files"] = renamed
+        return data

--- a/pyzap/plugins/sql_store.py
+++ b/pyzap/plugins/sql_store.py
@@ -1,0 +1,22 @@
+"""Store payload in a SQLite table."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any, Dict
+
+from ..core import BaseAction
+
+
+class SqlStoreAction(BaseAction):
+    """Save data as JSON in a SQLite database."""
+
+    def execute(self, data: Dict[str, Any]) -> None:
+        db = self.params.get("db", "data.db")
+        table = self.params.get("table", "records")
+        conn = sqlite3.connect(db)
+        conn.execute(f"CREATE TABLE IF NOT EXISTS {table} (data TEXT)")
+        conn.execute(f"INSERT INTO {table} (data) VALUES (?)", [json.dumps(data)])
+        conn.commit()
+        conn.close()


### PR DESCRIPTION
## Summary
- extend Excel polling plugin with additional triggers
- add actions for Excel upserts and file handling
- document Excel features
- test new plugins and actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688775b64260832db952ce496ad32033