### PR TITLE
Enhance gmail archive output and pdf split

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ that can be appended to a spreadsheet:
   detected in both plain text and HTML `href` attributes and file names are
   derived from `Content-Disposition` headers when needed, and
   automatically fetch text parts delivered via `attachmentId`. Quoted replies
-  are stripped from the saved message.
+  are stripped from the saved message. When attachments are stored locally the
+  action also returns `attachment_paths` with their full paths.
 * `imap_archive` &ndash; similar functionality for standard IMAP servers. It
   requires `host`, `username` and `password` and the same destination options as
   `gmail_archive`.

--- a/config.json
+++ b/config.json
@@ -31,7 +31,8 @@
         "download_links": true
       }
         },
-        {"type": "excel_append", "params": {"file": "../gmail/log.xlsx"}}
+        {"type": "excel_append", "params": {"file": "../gmail/log.xlsx"}},
+        {"type": "pdf_split", "params": {"output_dir": "../gmail/split"}}
       ]
     }
   ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,10 +95,14 @@ metadata into spreadsheet appenders:
         "download_links": true
       }
     },
-    {"type": "excel_append", "params": {"file": "log.xlsm"}}
+    {"type": "excel_append", "params": {"file": "log.xlsm"}},
+    {"type": "pdf_split", "params": {"output_dir": "./split"}}
   ]
 }
 ```
+
+`pdf_split` will use the `attachment_paths` field from `gmail_archive` when
+`pdf_path` is not provided.
 
 The same concept works with `imap_archive` in place of `gmail_archive` and the
 `sheets_append` action for Google Sheets.
@@ -130,4 +134,5 @@ Related actions can modify Excel files or work with row data:
 * `attachment_download` &ndash; download files referenced in a row and optionally
   rename them based on placeholders.
 * `pdf_split` &ndash; split a PDF into separate files using a text pattern and
-  naming template.
+  naming template. If `pdf_path` is omitted it uses the first
+  `attachment_paths` entry from the previous action.

--- a/pyzap/plugins/gmail_archive.py
+++ b/pyzap/plugins/gmail_archive.py
@@ -216,6 +216,8 @@ class GmailArchiveAction(BaseAction):
                 uploader.execute({"content": content, "filename": name})
             storage_path = folder_id
 
+        file_paths = [str(Path(storage_path) / name) for name, _ in files]
+
         return {
             "datetime": date,
             "sender": sender,
@@ -223,4 +225,5 @@ class GmailArchiveAction(BaseAction):
             "summary": snippet,
             "attachments": attachments,
             "storage_path": storage_path,
+            "attachment_paths": file_paths,
         }

--- a/pyzap/plugins/pdf_split.py
+++ b/pyzap/plugins/pdf_split.py
@@ -19,6 +19,10 @@ class PDFSplitAction(BaseAction):
             ) from exc
 
         pdf_path = data.get("pdf_path")
+        if not pdf_path:
+            paths = data.get("attachment_paths")
+            if paths:
+                pdf_path = paths[0]
         output_dir = self.params.get("output_dir")
         pattern = self.params.get("pattern")
         name_template = self.params.get("name_template", "split_{index}.pdf")

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -394,6 +394,7 @@ def test_gmail_archive(monkeypatch, tmp_path):
     assert folder.exists()
     assert (folder / 'a.txt').read_bytes() == b'file'
     assert result['sender'] == 'f'
+    assert result['attachment_paths'] == [str(folder / 'a.txt')]
 
 
 def test_gmail_archive_filtered(monkeypatch, tmp_path):
@@ -412,6 +413,7 @@ def test_gmail_archive_filtered(monkeypatch, tmp_path):
     folder = tmp_path / '123'
     assert not folder.exists()
     assert result['attachments'] == []
+    assert result['attachment_paths'] == []
     assert result['storage_path'] == ''
 
 
@@ -431,6 +433,7 @@ def test_gmail_archive_skip_attachments(monkeypatch, tmp_path):
     assert folder.exists()
     assert not (folder / 'a.txt').exists()
     assert result['attachments'] == []
+    assert result['attachment_paths'] == []
 
 
 def test_gmail_archive_links(monkeypatch, tmp_path):
@@ -466,6 +469,7 @@ def test_gmail_archive_links(monkeypatch, tmp_path):
     assert (folder / 'message.txt').read_text() == 'body http://example.com/file.pdf'
     assert (folder / 'file.pdf').read_bytes() == b'linked'
     assert 'file.pdf' in result['attachments']
+    assert result['attachment_paths'] == [str(folder / 'file.pdf')]
 
 
 def test_gmail_archive_links_no_attachments(monkeypatch, tmp_path):
@@ -498,6 +502,7 @@ def test_gmail_archive_links_no_attachments(monkeypatch, tmp_path):
     assert folder.exists()
     assert (folder / 'file.pdf').read_bytes() == b'linked'
     assert result['attachments'] == ['file.pdf']
+    assert result['attachment_paths'] == [str(folder / 'file.pdf')]
 
 
 def test_gmail_archive_token_from_message(monkeypatch, tmp_path):
@@ -512,6 +517,7 @@ def test_gmail_archive_token_from_message(monkeypatch, tmp_path):
     folder = tmp_path / '123'
     assert folder.exists()
     assert result['sender'] == 'f'
+    assert result['attachment_paths'] == [str(folder / 'a.txt')]
 
 
 def test_gmail_archive_html_link_header(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- return attachment paths from `gmail_archive`
- support using archived attachments in `pdf_split`
- update docs and example config with new `pdf_split` step
- adjust tests for new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688946dd3374832d85931296eecf094e