### PR TITLE
Improve PDFSplit filename handling

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -134,5 +134,7 @@ Related actions can modify Excel files or work with row data:
 * `attachment_download` &ndash; download files referenced in a row and optionally
   rename them based on placeholders.
 * `pdf_split` &ndash; split a PDF into separate files using a text pattern and
-  naming template. If `pdf_path` is omitted it uses the first
+  naming template. Filenames are automatically sanitised to remove characters
+  that are not allowed by the operating system and are truncated to keep paths
+  reasonably short. If `pdf_path` is omitted it uses the first
   `attachment_paths` entry from the previous action.


### PR DESCRIPTION
## Summary
- sanitize output filenames for `pdf_split` action to avoid invalid characters and long paths
- document automatic filename sanitisation
- test filename sanitisation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889945e1570832dac85dfc48243da99