### PR TITLE
Improve PDF table field extraction

### DIFF
--- a/pyzap/pdf_utils.py
+++ b/pyzap/pdf_utils.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+
+def extract_table_row(text: str, columns: Iterable[Any]) -> Dict[str, str]:
+    """Extract a single row of table data from ``text``.
+
+    ``columns`` may be an iterable of strings or dictionaries with keys:
+    ``header`` (header text), ``key`` (output key) and optional ``tokens`` to
+    specify how many tokens to assign to the column. The last column always
+    receives any remaining tokens.
+    """
+
+    lines = [l.strip() for l in text.replace("\r", "").split("\n") if l.strip()]
+    if len(lines) < 2:
+        return {}
+
+    specs: List[Dict[str, Any]] = []
+    for col in columns:
+        if isinstance(col, str):
+            specs.append({"header": col, "key": col, "tokens": None})
+        else:
+            specs.append({
+                "header": col.get("header") or col.get("name"),
+                "key": col.get("key") or col.get("name"),
+                "tokens": col.get("tokens"),
+            })
+
+    headers = [s["header"] for s in specs]
+    header_idx = None
+    for i, line in enumerate(lines[:-1]):
+        if all(h and h.lower() in line.lower() for h in headers):
+            header_idx = i
+            break
+    if header_idx is None or header_idx + 1 >= len(lines):
+        return {}
+
+    value_tokens = lines[header_idx + 1].split()
+    result: Dict[str, str] = {}
+    idx = 0
+    for j, spec in enumerate(specs):
+        remaining = len(value_tokens) - idx
+        if remaining <= 0:
+            value = ""
+        elif j == len(specs) - 1:
+            value = " ".join(value_tokens[idx:])
+            idx = len(value_tokens)
+        else:
+            tokens = spec["tokens"] if spec["tokens"] is not None else 1
+            tokens = max(0, min(tokens, remaining))
+            value = " ".join(value_tokens[idx : idx + tokens])
+            idx += tokens
+        result[spec["key"]] = value
+
+    return result

--- a/pyzap/plugins/pdf_split.py
+++ b/pyzap/plugins/pdf_split.py
@@ -19,6 +19,7 @@ def _safe_filename(name: str, max_length: int = 100) -> str:
     return name
 
 from ..core import BaseAction
+from ..pdf_utils import extract_table_row
 
 
 class PDFSplitAction(BaseAction):
@@ -41,6 +42,7 @@ class PDFSplitAction(BaseAction):
         pattern = self.params.get("pattern")
         name_template = self.params.get("name_template", "split_{index}.pdf")
         regex_fields: Dict[str, str] = self.params.get("regex_fields", {})
+        table_fields = self.params.get("table_fields")
 
         if not pdf_path:
             raise ValueError("pdf_path parameter required")
@@ -82,6 +84,12 @@ class PDFSplitAction(BaseAction):
                         value = m.group(1) if m.groups() else m.group(0)
                         if isinstance(value, str):
                             value = re.sub(r"\s+", " ", value.strip())
+                        fields[key] = value
+
+            if table_fields:
+                table_data = extract_table_row(text, table_fields)
+                for key, value in table_data.items():
+                    if key not in fields:
                         fields[key] = value
 
         if writer and len(getattr(writer, "pages", [])) > 0:

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -964,3 +964,28 @@ def test_pdf_split_sanitized_filename(monkeypatch, tmp_path):
     # filename should be truncated and invalid characters replaced
     assert len(fname) <= 100
     assert ':' not in fname and '|' not in fname and '<' not in fname
+
+
+def test_extract_table_row():
+    from pyzap.pdf_utils import extract_table_row
+
+    text = (
+        'Tipologia documento Art. 73 Numero documento Data documento Codice destinatario\n'
+        'TD01 fattura 32 23-07-2025 6RB0OU9'
+    )
+    columns = [
+        {'header': 'Tipologia documento', 'key': 'tipologia', 'tokens': 2},
+        {'header': 'Art. 73', 'key': 'art_73', 'tokens': 0},
+        {'header': 'Numero documento', 'key': 'numero'},
+        {'header': 'Data documento', 'key': 'data'},
+        {'header': 'Codice destinatario', 'key': 'dest'}
+    ]
+
+    result = extract_table_row(text, columns)
+    assert result == {
+        'tipologia': 'TD01 fattura',
+        'art_73': '',
+        'numero': '32',
+        'data': '23-07-2025',
+        'dest': '6RB0OU9'
+    }


### PR DESCRIPTION
## Summary
- add `pdf_utils.extract_table_row` to handle table-type fields
- support optional `table_fields` in `PDFSplitAction`
- test table field extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68899a1d1e60832d997285c819c9bb66