### PR TITLE
Add invoice parsing option to PDF splitter

### DIFF
--- a/Config.json.help
+++ b/Config.json.help
@@ -114,7 +114,7 @@ Parametri: dest (obbl.), rename opzionale
 Il file pyzap/plugins/pdf_split.py definisce l’azione PDFSplitAction, che divide un PDF in più file.
 
 Parametri:
-output_dir (obbligatorio), pattern per determinare i punti di split, name_template (predefinito split_{index}.pdf), regex_fields per estrarre campi dal testo
+output_dir (obbligatorio), pattern per determinare i punti di split, name_template (predefinito split_{index}.pdf), regex_fields per estrarre campi dal testo, parse_invoice (opzionale)
 
 **************
 6) Elenco Azione pdf_split
@@ -285,3 +285,4 @@ evitare di definire le stesse chiavi in regex_fields oppure rinominarle.
   ]
 }
 In questo modo i campi numero_documento e data_documento verranno presi dalla tabella del PDF e potranno essere utilizzati nel name_template per costruire correttamente il nome del file.
+Se il parametro parse_invoice è impostato a true il testo di ogni PDF viene analizzato con parse_invoice_text. Le chiavi annidate del risultato vengono appiattite con l'underscore (es. documento_numero) e rese disponibili nel name_template.

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,17 @@
+{
+  "workflows": [
+    {
+      "id": "invoice-split",
+      "trigger": {"type": "gmail_poll", "query": "label:invoices", "token_file": "token.json"},
+      "actions": [
+        {"type": "gmail_archive", "params": {"local_dir": "./archive", "attachment_types": [".pdf"]}},
+        {"type": "pdf_split", "params": {
+          "output_dir": "./split",
+          "pattern": "Cedente/prestatore",
+          "parse_invoice": true,
+          "name_template": "{documento_numero}_{cliente_denominazione}.pdf"
+        }}
+      ]
+    }
+  ]
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,4 +137,7 @@ Related actions can modify Excel files or work with row data:
   naming template. Filenames are automatically sanitised to remove characters
   that are not allowed by the operating system and are truncated to keep paths
   reasonably short. If `pdf_path` is omitted it uses the first
-  `attachment_paths` entry from the previous action.
+  `attachment_paths` entry from the previous action. Setting `parse_invoice` to
+  `true` parses each chunk with `parse_invoice_text` making placeholders like
+  `{documento_numero}` or `{cliente_denominazione}` available for the
+  `name_template`.


### PR DESCRIPTION
## Summary
- parse invoices in `pdf_split` when `parse_invoice` option is enabled
- store parsed data in output records and allow invoice placeholders in filenames
- test new feature in `tests/test_action.py`
- document `parse_invoice` parameter and placeholders
- provide example `config.json.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b83f576d8832d82898e5236783787