### PR TITLE
Improve OCR invoice table parsing

### DIFF
--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1057,6 +1057,30 @@ def test_parse_invoice_text():
     assert data['pagamento']['modalita'] == 'Bonifico'
 
 
+def test_parse_invoice_text_table_header():
+    from pyzap.pdf_utils import parse_invoice_text
+
+    text = (
+        'Cedente/prestatore (fornitore)\n'
+        'Denominazione: Fornitore SRL\n'
+        'Cessionario/committente (cliente)\n'
+        'Denominazione: Cliente SPA\n'
+        'Tipologia documento Art.\n'
+        '73 Numero documento Data documento Codice\n'
+        'destinatario\n'
+        'TD01 fattura 32 23-07-2025\n'
+        '6RB0OU9\n'
+        'Totale documento 122,00\n'
+    )
+
+    data = parse_invoice_text(text)
+
+    assert data['documento']['tipo'] == 'TD01 fattura'
+    assert data['documento']['numero'] == '32'
+    assert data['documento']['data'] == '23-07-2025'
+    assert data['documento']['codice_destinatario'] == '6RB0OU9'
+
+
 def test_pdf_split_parse_invoice(monkeypatch, tmp_path):
     text = (
         'start Cedente/prestatore (fornitore)\n'


### PR DESCRIPTION
## Summary
- make `parse_invoice_text` search for the document table header and parse it with `extract_table_row`
- add regression test ensuring the table is parsed even when headers and values are split across lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba88bd6c0832d98d56531e490e475