### PR TITLE
Specify tokens for Codice destinatario

### DIFF
--- a/pyzap/pdf_utils.py
+++ b/pyzap/pdf_utils.py
@@ -123,7 +123,7 @@ def parse_invoice_text(text: str) -> Dict[str, Any]:
         {"header": "Art. 73", "key": "art_73", "tokens": 0},
         {"header": "Numero documento", "key": "numero"},
         {"header": "Data documento", "key": "data"},
-        {"header": "Codice destinatario", "key": "codice_destinatario"},
+        {"header": "Codice destinatario", "key": "codice_destinatario", "tokens": 1},
     ]
     doc_row = {}
     for idx, line in enumerate(lines):


### PR DESCRIPTION
## Summary
- update `parse_invoice_text` to specify token allocation for the `"Codice destinatario"` column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bb3ccd628832da690f53e0132b270