### PR TITLE
Add date format customization for pdf_split

### DIFF
--- a/azienda.agricola-splitpdf.json
+++ b/azienda.agricola-splitpdf.json
@@ -43,8 +43,9 @@
           "params": {
             "output_dir": "../fatture/split",
             "pattern": "Cedente/prestatore \\(fornitore\\)",
-			"parse_invoice": true,
-            "name_template": "{documento_data} Fattura {documento_numero} {fornitore_denominazione}.pdf"
+                        "parse_invoice": true,
+            "name_template": "{documento_data} Fattura {documento_numero} {fornitore_denominazione}.pdf",
+            "date_formats": {"documento_data": "%Y-%m-%d"}
           }
         }
       ]

--- a/config.json.example
+++ b/config.json.example
@@ -9,7 +9,8 @@
           "output_dir": "./split",
           "pattern": "Cedente/prestatore",
           "parse_invoice": true,
-          "name_template": "{documento_numero}_{cliente_denominazione}.pdf"
+          "name_template": "{documento_numero}_{cliente_denominazione}.pdf",
+          "date_formats": {"documento_data": "%Y-%m-%d"}
         }}
       ]
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,4 +140,5 @@ Related actions can modify Excel files or work with row data:
   `attachment_paths` entry from the previous action. Setting `parse_invoice` to
   `true` parses each chunk with `parse_invoice_text` making placeholders like
   `{documento_numero}` or `{cliente_denominazione}` available for the
-  `name_template`.
+  `name_template`.  You can format date placeholders by specifying a
+  `date_formats` mapping with `strftime` patterns, e.g. `{ "documento_data": "%Y-%m-%d" }`.

--- a/pyzap/formatter.py
+++ b/pyzap/formatter.py
@@ -11,7 +11,7 @@ def clean_text(text: str) -> str:
 
 def parse_date(value: str) -> _dt.datetime:
     """Parse a date string."""
-    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%d-%m-%Y"):
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%d-%m-%Y", "%d/%m/%Y"):
         try:
             return _dt.datetime.strptime(value, fmt)
         except ValueError:


### PR DESCRIPTION
## Summary
- allow parsing dd/mm/yyyy in `parse_date`
- add `date_formats` support in `PDFSplitAction`
- document date formatting in docs
- include `date_formats` in example config and sample workflow
- test date format customisation

## Testing
- `pytest -q`
- `pytest tests/test_action.py::test_pdf_split_parse_invoice_date_format -q`


------
https://chatgpt.com/codex/tasks/task_e_688cf36948a8832db217713fa50e373a