### PR TITLE
Ensure Excel workbooks are closed

### DIFF
--- a/pyzap/plugins/excel_append.py
+++ b/pyzap/plugins/excel_append.py
@@ -40,51 +40,54 @@ class ExcelAppendAction(BaseAction):
 
         with excel_lock(file_path):
             wb = load_workbook(file_path, keep_vba=keep_vba)
-            ws = wb[sheet_name] if sheet_name else wb.active
-
-            if "values" in data:
-                values = data["values"]
-                field_names = [str(i) for i in range(len(values))]
-            else:
-                if not fields:
-                    fields = list(data.keys())
-                field_names = fields
-                values = [data.get(f) for f in fields]
-
-            def _convert(value: Any, name: str) -> Any:
-                if name == "storage_path" and not value:
-                    return None
-                if isinstance(value, str) and name in message_fields and max_message_length:
-                    value = value[:max_message_length]
-                if name == "datetime" and isinstance(value, str):
-                    try:
-                        dt = email.utils.parsedate_to_datetime(value)
-                        value = dt.strftime("%d/%m/%Y %H:%M:%S")
-                    except Exception:
-                        pass
-                if name == "attachments" and isinstance(value, (list, tuple)):
-                    return "; ".join(str(v) for v in value)
-                if isinstance(value, (list, tuple)):
-                    return ", ".join(str(v) for v in value)
-                if isinstance(value, dict):
-                    return json.dumps(value, ensure_ascii=False)
-                return value
-
-            row = [_convert(v, n) for v, n in zip(values, field_names)]
-            exists = False
             try:
-                rows = getattr(ws, "rows", None)
-                if rows is not None:
-                    if row in list(rows):
-                        exists = True
-                else:
-                    for existing in ws.values:
-                        if list(existing)[: len(row)] == row:
-                            exists = True
-                            break
-            except Exception:
-                pass
+                ws = wb[sheet_name] if sheet_name else wb.active
 
-            if not exists:
-                ws.append(row)
-                wb.save(file_path)
+                if "values" in data:
+                    values = data["values"]
+                    field_names = [str(i) for i in range(len(values))]
+                else:
+                    if not fields:
+                        fields = list(data.keys())
+                    field_names = fields
+                    values = [data.get(f) for f in fields]
+
+                def _convert(value: Any, name: str) -> Any:
+                    if name == "storage_path" and not value:
+                        return None
+                    if isinstance(value, str) and name in message_fields and max_message_length:
+                        value = value[:max_message_length]
+                    if name == "datetime" and isinstance(value, str):
+                        try:
+                            dt = email.utils.parsedate_to_datetime(value)
+                            value = dt.strftime("%d/%m/%Y %H:%M:%S")
+                        except Exception:
+                            pass
+                    if name == "attachments" and isinstance(value, (list, tuple)):
+                        return "; ".join(str(v) for v in value)
+                    if isinstance(value, (list, tuple)):
+                        return ", ".join(str(v) for v in value)
+                    if isinstance(value, dict):
+                        return json.dumps(value, ensure_ascii=False)
+                    return value
+
+                row = [_convert(v, n) for v, n in zip(values, field_names)]
+                exists = False
+                try:
+                    rows = getattr(ws, "rows", None)
+                    if rows is not None:
+                        if row in list(rows):
+                            exists = True
+                    else:
+                        for existing in ws.values:
+                            if list(existing)[: len(row)] == row:
+                                exists = True
+                                break
+                except Exception:
+                    pass
+
+                if not exists:
+                    ws.append(row)
+                    wb.save(file_path)
+            finally:
+                getattr(wb, "close", lambda: None)()

--- a/pyzap/plugins/excel_poll.py
+++ b/pyzap/plugins/excel_poll.py
@@ -49,29 +49,32 @@ class ExcelPollTrigger(BaseTrigger):
 
         with excel_lock(file_path):
             wb = load_workbook(file_path, read_only=True)
-            ws = wb[sheet_name] if sheet_name else wb.active
+            try:
+                ws = wb[sheet_name] if sheet_name else wb.active
 
-            max_row = getattr(ws, "max_row", None)
-            if max_row is None:
-                rows_attr = getattr(ws, "rows", [])
-                try:
-                    max_row = len(list(rows_attr))
-                except TypeError:
-                    max_row = len(rows_attr)
+                max_row = getattr(ws, "max_row", None)
+                if max_row is None:
+                    rows_attr = getattr(ws, "rows", [])
+                    try:
+                        max_row = len(list(rows_attr))
+                    except TypeError:
+                        max_row = len(rows_attr)
 
-            results: List[Dict[str, Any]] = []
-            for row_idx in range(self.last_row + 1, max_row + 1):
-                cells = ws[row_idx]
-                values = [getattr(c, "value", None) for c in cells]
-                match = True
-                for col, expected in filters.items():
-                    idx = int(col) - 1
-                    val = values[idx] if idx < len(values) else None
-                    if val != expected:
-                        match = False
-                        break
-                if match:
-                    results.append({"id": str(row_idx), "values": values})
+                results: List[Dict[str, Any]] = []
+                for row_idx in range(self.last_row + 1, max_row + 1):
+                    cells = ws[row_idx]
+                    values = [getattr(c, "value", None) for c in cells]
+                    match = True
+                    for col, expected in filters.items():
+                        idx = int(col) - 1
+                        val = values[idx] if idx < len(values) else None
+                        if val != expected:
+                            match = False
+                            break
+                    if match:
+                        results.append({"id": str(row_idx), "values": values})
+            finally:
+                getattr(wb, "close", lambda: None)()
 
         self.last_row = max_row
         self._save_state()


### PR DESCRIPTION
## Summary
- Wrap Excel append, poll, and watch operations in try/finally blocks to ensure workbooks are closed
- Close workbooks in Excel watch triggers and write action using safe `getattr` calls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dbe8fc1a8832d9ee342b72e1a4b5d