### PR TITLE
Close VBA archive when appending to Excel

### DIFF
--- a/pyzap/plugins/excel_append.py
+++ b/pyzap/plugins/excel_append.py
@@ -90,4 +90,5 @@ class ExcelAppendAction(BaseAction):
                     ws.append(row)
                     wb.save(file_path)
             finally:
+                getattr(getattr(wb, "vba_archive", None), "close", lambda: None)()
                 getattr(wb, "close", lambda: None)()


### PR DESCRIPTION
## Summary
- Ensure Excel append plugin closes any associated VBA archive and workbook in a finally block

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dc10cc850832d800cf2834eabd7a9