### PR TITLE
feat: support multiple record append in excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,12 @@ that can be appended to a spreadsheet:
   `gmail_archive`.
 
 The resulting metadata dictionary can be passed to `sheets_append` or the new
-`excel_append` action which writes rows to a local `.xlsx` or `.xlsm` workbook. The
-`excel_append` action formats the `datetime` field as `DD/MM/YYYY HH:MM:SS`,
-joins attachment lists with a semicolon and supports a `max_message_length`
-parameter to truncate the message text.
+`excel_append` action which writes rows to a local `.xlsx` or `.xlsm` workbook.
+`excel_append` formats the `datetime` field as `DD/MM/YYYY HH:MM:SS`, joins
+attachment lists with a semicolon and supports a `max_message_length`
+parameter to truncate the message text. It now also accepts a `records` key
+containing a list of dictionaries with the same fields configured in
+`fields` allowing multiple rows to be appended in a single call.
 
 ## Logging
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,10 @@ metadata into spreadsheet appenders:
 }
 ```
 
+The `excel_append` action also accepts a `records` key containing a list of
+objects with the same fields configured in `fields`, allowing multiple rows to
+be appended in one execution.
+
 `pdf_split` will use the `attachment_paths` field from `gmail_archive` when
 `pdf_path` is not provided.
 

--- a/pyzap/plugins/excel_append.py
+++ b/pyzap/plugins/excel_append.py
@@ -43,14 +43,22 @@ class ExcelAppendAction(BaseAction):
             try:
                 ws = wb[sheet_name] if sheet_name else wb.active
 
-                if "values" in data:
+                rows_data: List[List[Any]]
+                if isinstance(data.get("records"), list):
+                    records = data["records"]
+                    if not fields and records:
+                        fields = list(records[0].keys())
+                    field_names = fields
+                    rows_data = [[record.get(f) for f in field_names] for record in records]
+                elif "values" in data:
                     values = data["values"]
                     field_names = [str(i) for i in range(len(values))]
+                    rows_data = [values]
                 else:
                     if not fields:
                         fields = list(data.keys())
                     field_names = fields
-                    values = [data.get(f) for f in fields]
+                    rows_data = [[data.get(f) for f in fields]]
 
                 def _convert(value: Any, name: str) -> Any:
                     if name == "storage_path" and not value:
@@ -71,23 +79,28 @@ class ExcelAppendAction(BaseAction):
                         return json.dumps(value, ensure_ascii=False)
                     return value
 
-                row = [_convert(v, n) for v, n in zip(values, field_names)]
-                exists = False
-                try:
-                    rows = getattr(ws, "rows", None)
-                    if rows is not None:
-                        if row in list(rows):
-                            exists = True
-                    else:
-                        for existing in ws.values:
-                            if list(existing)[: len(row)] == row:
+                appended = False
+                for values in rows_data:
+                    row = [_convert(v, n) for v, n in zip(values, field_names)]
+                    exists = False
+                    try:
+                        rows = getattr(ws, "rows", None)
+                        if rows is not None:
+                            if row in list(rows):
                                 exists = True
-                                break
-                except Exception:
-                    pass
+                        else:
+                            for existing in ws.values:
+                                if list(existing)[: len(row)] == row:
+                                    exists = True
+                                    break
+                    except Exception:
+                        pass
 
-                if not exists:
-                    ws.append(row)
+                    if not exists:
+                        ws.append(row)
+                        appended = True
+
+                if appended:
                     wb.save(file_path)
             finally:
                 getattr(getattr(wb, "vba_archive", None), "close", lambda: None)()


### PR DESCRIPTION
## Summary
- allow `excel_append` to append multiple records from a `records` list
- document the new `records` option for Excel append
- test appending multiple records to Excel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dd0a32e28832da10f23cfd82abf5e