### PR TITLE
Add GUI editor for workflow config

### DIFF
--- a/pyzap/webapp.py
+++ b/pyzap/webapp.py
@@ -1,36 +1,114 @@
-"""Minimal Flask dashboard for PyZap."""
+"""Minimal Flask dashboard for PyZap.
 
-from flask import Flask, jsonify, render_template_string, request
+This module now exposes a small interface to inspect, create and edit
+workflow definitions stored in ``config.json``.  The aim is to guide the
+user through the process of assembling a workflow without having to edit
+the raw JSON by hand.
+"""
+
+import json
+
+from flask import (
+    Flask,
+    jsonify,
+    redirect,
+    render_template_string,
+    request,
+    url_for,
+)
 
 from .config import load_config, save_config
 
 app = Flask(__name__)
 CONFIG_PATH = "config.json"
 
-TEMPLATE = """
+INDEX_TEMPLATE = """
 <!doctype html>
 <title>PyZap Workflows</title>
 <h1>Workflows</h1>
+<p><a href="{{ url_for('edit_workflow') }}">Nuovo workflow</a></p>
 <ul>
 {% for wf in workflows %}
-    <li>{{ wf.id }} - {{ 'enabled' if wf.get('enabled', True) else 'disabled' }}</li>
+    <li>
+        {{ wf.id }} - {{ 'enabled' if wf.get('enabled', True) else 'disabled' }}
+        [<a href="{{ url_for('edit_workflow', index=loop.index0) }}">modifica</a>]
+    </li>
 {% endfor %}
 </ul>
 """
+
+EDIT_TEMPLATE = """
+<!doctype html>
+<title>Workflow editor</title>
+<h1>{{ 'Nuovo' if index is none else 'Modifica' }} workflow</h1>
+<form method="post">
+  <label>ID<br><input name="id" value="{{ wf.id }}" required></label><br>
+  <h2>Trigger</h2>
+  <label>Tipo<br><input name="trigger_type" value="{{ wf.trigger.type }}" required></label><br>
+  <label>Query<br><input name="trigger_query" value="{{ wf.trigger.query }}"></label><br>
+  <label>Token file<br><input name="trigger_token_file" value="{{ wf.trigger.token_file }}"></label><br>
+  <h2>Azioni</h2>
+  <p>Inserisci un array JSON di azioni.</p>
+  <textarea name="actions" rows="10" cols="80">{{ wf.actions | tojson(indent=2) }}</textarea><br>
+  <button type="submit">Salva</button>
+</form>
+<p><a href="{{ url_for('index') }}">Torna alla lista</a></p>
+"""
+
+
+def _get_workflows(cfg):
+    """Extract the list of workflows from the loaded config."""
+    return cfg.get("workflows", []) if isinstance(cfg, dict) else cfg
 
 
 @app.route("/")
 def index():
     cfg = load_config(CONFIG_PATH)
-    workflows = cfg.get("workflows", []) if isinstance(cfg, dict) else cfg
-    return render_template_string(TEMPLATE, workflows=workflows)
+    workflows = _get_workflows(cfg)
+    return render_template_string(INDEX_TEMPLATE, workflows=workflows)
+
+
+@app.route("/workflow/new", methods=["GET", "POST"])
+@app.route("/workflow/<int:index>", methods=["GET", "POST"])
+def edit_workflow(index=None):
+    cfg = load_config(CONFIG_PATH)
+    workflows = _get_workflows(cfg)
+
+    if request.method == "POST":
+        wf = {
+            "id": request.form["id"],
+            "trigger": {
+                "type": request.form.get("trigger_type", ""),
+                "query": request.form.get("trigger_query", ""),
+                "token_file": request.form.get("trigger_token_file", ""),
+            },
+            "actions": json.loads(request.form.get("actions", "[]")),
+        }
+        if index is None:
+            workflows.append(wf)
+        else:
+            workflows[index] = wf
+        if isinstance(cfg, dict):
+            cfg["workflows"] = workflows
+            save_config(CONFIG_PATH, cfg)
+        else:
+            save_config(CONFIG_PATH, workflows)
+        return redirect(url_for("index"))
+
+    wf = (
+        workflows[index]
+        if index is not None and index < len(workflows)
+        else {"id": "", "trigger": {"type": "", "query": "", "token_file": ""}, "actions": []}
+    )
+    return render_template_string(EDIT_TEMPLATE, wf=wf, index=index)
 
 
 @app.route("/api/workflows", methods=["POST"])
-def create_workflow():
+def create_workflow_api():
+    """Legacy API endpoint used by tests or scripts."""
     data = request.get_json()
     cfg = load_config(CONFIG_PATH)
-    workflows = cfg.get("workflows", []) if isinstance(cfg, dict) else cfg
+    workflows = _get_workflows(cfg)
     workflows.append(data)
     if isinstance(cfg, dict):
         cfg["workflows"] = workflows

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,39 @@
+"""Tests for the minimal GUI web application."""
+
+import json
+
+from pyzap.webapp import app, CONFIG_PATH
+
+
+def test_index_route(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"workflows": []}))
+    monkeypatch.setattr("pyzap.webapp.CONFIG_PATH", str(cfg_path))
+
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"Workflows" in resp.data
+
+
+def test_create_workflow_via_form(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"workflows": []}))
+    monkeypatch.setattr("pyzap.webapp.CONFIG_PATH", str(cfg_path))
+
+    client = app.test_client()
+    resp = client.post(
+        "/workflow/new",
+        data={
+            "id": "wf1",
+            "trigger_type": "manual",
+            "trigger_query": "",
+            "trigger_token_file": "",
+            "actions": "[]",
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+
+    data = json.loads(cfg_path.read_text())
+    assert data["workflows"][0]["id"] == "wf1"


### PR DESCRIPTION
## Summary
- extend Flask webapp with forms to create and edit workflows stored in `config.json`
- add tests covering new GUI routes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688de6774414832d993565c1aa8f351a