### PR TITLE
Handle invalid JSON in workflow editor

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -37,3 +37,23 @@ def test_create_workflow_via_form(tmp_path, monkeypatch):
 
     data = json.loads(cfg_path.read_text())
     assert data["workflows"][0]["id"] == "wf1"
+
+
+def test_invalid_json_actions(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"workflows": []}))
+    monkeypatch.setattr("pyzap.webapp.CONFIG_PATH", str(cfg_path))
+
+    client = app.test_client()
+    resp = client.post(
+        "/workflow/new",
+        data={
+            "id": "wf1",
+            "trigger_type": "manual",
+            "trigger_query": "",
+            "trigger_token_file": "",
+            "actions": "[invalid",
+        },
+    )
+    assert resp.status_code == 200
+    assert b"Invalid JSON" in resp.data


### PR DESCRIPTION
## Summary
- Show an error in workflow editor when the actions JSON cannot be parsed
- Keep user input and avoid crashing on bad JSON
- Test invalid JSON handling in web editor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688de9db25f4832da4eacec8239b0879