### PR TITLE
Refactor workflow saving into helper

### DIFF
--- a/pyzap/webapp.py
+++ b/pyzap/webapp.py
@@ -64,6 +64,15 @@ def _get_workflows(cfg):
     return cfg.get("workflows", []) if isinstance(cfg, dict) else cfg
 
 
+def _save_workflows(cfg, workflows):
+    """Persist the updated workflows back to ``CONFIG_PATH``."""
+    if isinstance(cfg, dict):
+        cfg["workflows"] = workflows
+        save_config(CONFIG_PATH, cfg)
+    else:
+        save_config(CONFIG_PATH, workflows)
+
+
 @app.route("/")
 def index():
     cfg = load_config(CONFIG_PATH)
@@ -112,11 +121,7 @@ def edit_workflow(index=None):
             workflows.append(wf)
         else:
             workflows[index] = wf
-        if isinstance(cfg, dict):
-            cfg["workflows"] = workflows
-            save_config(CONFIG_PATH, cfg)
-        else:
-            save_config(CONFIG_PATH, workflows)
+        _save_workflows(cfg, workflows)
         return redirect(url_for("index"))
 
     wf = (
@@ -137,11 +142,7 @@ def create_workflow_api():
     cfg = load_config(CONFIG_PATH)
     workflows = _get_workflows(cfg)
     workflows.append(data)
-    if isinstance(cfg, dict):
-        cfg["workflows"] = workflows
-        save_config(CONFIG_PATH, cfg)
-    else:
-        save_config(CONFIG_PATH, workflows)
+    _save_workflows(cfg, workflows)
     return jsonify({"status": "ok"})
 
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -57,3 +57,23 @@ def test_invalid_json_actions(tmp_path, monkeypatch):
     )
     assert resp.status_code == 200
     assert b"Invalid JSON" in resp.data
+
+
+def test_create_workflow_via_api(tmp_path, monkeypatch):
+    """Ensure the API saves workflows when config is a plain list."""
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text("[]")
+    monkeypatch.setattr("pyzap.webapp.CONFIG_PATH", str(cfg_path))
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/workflows",
+        json={
+            "id": "wf_api",
+            "trigger": {"type": "manual", "query": "", "token_file": ""},
+            "actions": [],
+        },
+    )
+    assert resp.status_code == 200
+    data = json.loads(cfg_path.read_text())
+    assert data[0]["id"] == "wf_api"


### PR DESCRIPTION
## Summary
- add `_save_workflows` to centralize updating and persisting workflows
- replace duplicated save logic in `edit_workflow` and `create_workflow_api`
- cover API workflow creation with new test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688deb79eab4832d96894f0eed6fada9