### PR TITLE
Handle missing action params

### DIFF
--- a/pyzap/templates/edit_workflow.html
+++ b/pyzap/templates/edit_workflow.html
@@ -105,7 +105,7 @@
                 </div>
                 <h6>Parametri</h6>
                 <div class="action-params">
-                {% for key, value in action.params.items() %}
+                {% for key, value in (action.params|default({})).items() %}
                     <div class="row align-items-center mb-2 param-row">
                         <div class="col-5">
                             <input type="text" class="form-control" name="action_{{ action_index }}_param_key_{{ loop.index0 }}" placeholder="Nome Parametro" value="{{ key }}">

--- a/tests/test_render_edit_workflow.py
+++ b/tests/test_render_edit_workflow.py
@@ -33,3 +33,20 @@ def test_edit_workflow_template_renders_action_params():
 
     assert 'name="action_0_param_key_0"' in html
     assert 'name="action_0_param_value_0"' in html
+
+
+def test_edit_workflow_template_renders_without_params():
+    """Template renders when actions have no params dictionary."""
+    cfg = {"admin_email": "", "smtp": {}}
+    workflow = {
+        "id": "wf1",
+        "trigger": {"type": "manual"},
+        "actions": [{"type": "email"}],
+    }
+
+    with app.test_request_context():
+        html = render_template(
+            "edit_workflow.html", cfg=cfg, wf=workflow, index=0, is_new=False
+        )
+
+    assert 'name="action_0_param_key_0"' not in html


### PR DESCRIPTION
## Summary
- Avoid template crash when action params are missing by defaulting to empty dict
- Add coverage verifying edit workflow template renders even without action params

## Testing
- `pytest tests/test_render_edit_workflow.py::test_edit_workflow_template_renders_without_params -q`
- `pytest -q` *(fails: tests/test_webapp.py::test_invalid_json_actions, tests/test_webapp.py::test_create_workflow_via_api, tests/test_webapp.py::test_edit_workflow_via_form)*


------
https://chatgpt.com/codex/tasks/task_e_688f09d37b34832d8eb5175e790d5ca1