### PR TITLE
Expose plugin metadata and add help section

### DIFF
--- a/pyzap/templates/edit_workflow.html
+++ b/pyzap/templates/edit_workflow.html
@@ -17,6 +17,34 @@
         </div>
     </div>
 
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+
+    {% if plugins %}
+    <!-- Help section for available triggers and actions -->
+    <div class="card mb-3" id="plugin-help">
+        <div class="card-header">Guida Trigger e Azioni</div>
+        <div class="card-body">
+            <h5>Trigger</h5>
+            {% for trig in plugins.triggers %}
+            <details class="mb-2">
+                <summary>{{ trig.name }}</summary>
+                <p>{{ trig.doc }}</p>
+            </details>
+            {% endfor %}
+
+            <h5 class="mt-3">Azioni</h5>
+            {% for act in plugins.actions %}
+            <details class="mb-2">
+                <summary>{{ act.name }}</summary>
+                <p>{{ act.doc }}</p>
+            </details>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
     <!-- Global Settings -->
     <div class="card">
         <div class="card-header">Impostazioni Globali</div>

--- a/pyzap/templates/index.html
+++ b/pyzap/templates/index.html
@@ -21,9 +21,12 @@
 <div class="card">
     <div class="card-header d-flex justify-content-between align-items-center">
         Workflows
-        <a href="{{ url_for('edit_workflow') }}" class="btn btn-primary">
-            <i class="bi bi-plus-circle"></i> Nuovo Workflow
-        </a>
+        <div>
+            <a href="{{ url_for('edit_workflow') }}#plugin-help" class="btn btn-link">Guida Trigger/Azioni</a>
+            <a href="{{ url_for('edit_workflow') }}" class="btn btn-primary">
+                <i class="bi bi-plus-circle"></i> Nuovo Workflow
+            </a>
+        </div>
     </div>
     <div class="list-group list-group-flush">
         {% for wf in workflows %}


### PR DESCRIPTION
## Summary
- load plugins at webapp startup and provide a helper to expose trigger/action docs
- add collapsible trigger/action help card in workflow editor with link from main index

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f5f3b0e10832d8a5b1365b8d8c0e3