### PR TITLE
Add trigger/action editing routes and templates

### DIFF
--- a/pyzap/templates/edit_action.html
+++ b/pyzap/templates/edit_action.html
@@ -1,0 +1,53 @@
+{% extends "layout.html" %}
+{% block title %}Modifica Azione{% endblock %}
+
+{% block content %}
+<form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="mb-3">
+        <label class="form-label">Tipo Azione</label>
+        <select class="form-select" name="action_type">
+            {% for name in actions.keys() %}
+            <option value="{{ name }}" {% if action.get('type') == name %}selected{% endif %}>{{ name }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <h5>Parametri</h5>
+    <div id="params">
+        {% for key, value in (action.get('params') or {}).items() %}
+        <div class="row align-items-center mb-2 param-row">
+            <div class="col-5"><input type="text" class="form-control" name="param_key_{{ loop.index0 }}" value="{{ key }}"></div>
+            <div class="col-5"><input type="text" class="form-control" name="param_value_{{ loop.index0 }}" value="{{ value }}"></div>
+            <div class="col-2"><button type="button" class="btn btn-sm btn-danger" onclick="this.closest('.param-row').remove()"><i class="bi bi-trash"></i></button></div>
+        </div>
+        {% endfor %}
+    </div>
+    <button type="button" class="btn btn-sm btn-outline-success" onclick="addParam()"><i class="bi bi-plus-circle"></i> Aggiungi Parametro</button>
+    <div class="mt-3">
+        <a href="{{ url_for('edit_workflow', index=wf_index) }}" class="btn btn-secondary">Annulla</a>
+        <button type="submit" class="btn btn-primary">Salva</button>
+    </div>
+</form>
+
+<template id="param-template">
+    <div class="row align-items-center mb-2 param-row">
+        <div class="col-5"><input type="text" class="form-control" name="param_key_idx" placeholder="Nome Parametro"></div>
+        <div class="col-5"><input type="text" class="form-control" name="param_value_idx" placeholder="Valore"></div>
+        <div class="col-2"><button type="button" class="btn btn-sm btn-danger" onclick="this.closest('.param-row').remove()"><i class="bi bi-trash"></i></button></div>
+    </div>
+</template>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function addParam() {
+    const container = document.getElementById('params');
+    const template = document.getElementById('param-template');
+    const clone = template.content.cloneNode(true);
+    const idx = container.querySelectorAll('.param-row').length;
+    clone.querySelector('[name="param_key_idx"]').name = `param_key_${idx}`;
+    clone.querySelector('[name="param_value_idx"]').name = `param_value_${idx}`;
+    container.appendChild(clone);
+}
+</script>
+{% endblock %}

--- a/pyzap/templates/edit_trigger.html
+++ b/pyzap/templates/edit_trigger.html
@@ -1,0 +1,55 @@
+{% extends "layout.html" %}
+{% block title %}Modifica Trigger{% endblock %}
+
+{% block content %}
+<form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="mb-3">
+        <label class="form-label">Tipo Trigger</label>
+        <select class="form-select" name="trigger_type">
+            {% for name in triggers.keys() %}
+            <option value="{{ name }}" {% if trigger.get('type') == name %}selected{% endif %}>{{ name }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <h5>Parametri</h5>
+    <div id="params">
+        {% for key, value in trigger.items() %}
+        {% if key != 'type' %}
+        <div class="row align-items-center mb-2 param-row">
+            <div class="col-5"><input type="text" class="form-control" name="param_key_{{ loop.index0 }}" value="{{ key }}"></div>
+            <div class="col-5"><input type="text" class="form-control" name="param_value_{{ loop.index0 }}" value="{{ value }}"></div>
+            <div class="col-2"><button type="button" class="btn btn-sm btn-danger" onclick="this.closest('.param-row').remove()"><i class="bi bi-trash"></i></button></div>
+        </div>
+        {% endif %}
+        {% endfor %}
+    </div>
+    <button type="button" class="btn btn-sm btn-outline-success" onclick="addParam()"><i class="bi bi-plus-circle"></i> Aggiungi Parametro</button>
+    <div class="mt-3">
+        <a href="{{ url_for('edit_workflow', index=wf_index) }}" class="btn btn-secondary">Annulla</a>
+        <button type="submit" class="btn btn-primary">Salva</button>
+    </div>
+</form>
+
+<template id="param-template">
+    <div class="row align-items-center mb-2 param-row">
+        <div class="col-5"><input type="text" class="form-control" name="param_key_idx" placeholder="Nome Parametro"></div>
+        <div class="col-5"><input type="text" class="form-control" name="param_value_idx" placeholder="Valore"></div>
+        <div class="col-2"><button type="button" class="btn btn-sm btn-danger" onclick="this.closest('.param-row').remove()"><i class="bi bi-trash"></i></button></div>
+    </div>
+</template>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function addParam() {
+    const container = document.getElementById('params');
+    const template = document.getElementById('param-template');
+    const clone = template.content.cloneNode(true);
+    const idx = container.querySelectorAll('.param-row').length;
+    clone.querySelector('[name="param_key_idx"]').name = `param_key_${idx}`;
+    clone.querySelector('[name="param_value_idx"]').name = `param_value_${idx}`;
+    container.appendChild(clone);
+}
+</script>
+{% endblock %}

--- a/pyzap/templates/edit_workflow.html
+++ b/pyzap/templates/edit_workflow.html
@@ -88,7 +88,12 @@
     
     <!-- Trigger -->
     <div class="card">
-        <div class="card-header">Trigger</div>
+        <div class="card-header d-flex justify-content-between align-items-center">
+            Trigger
+            {% if not is_new %}
+            <a href="{{ url_for('edit_trigger_route', wf=index) }}" class="btn btn-sm btn-outline-primary">Modifica</a>
+            {% endif %}
+        </div>
         <div class="card-body" id="trigger-params">
              {% for key, value in wf.trigger.items() %}
              <div class="row align-items-center mb-2 param-row">
@@ -124,7 +129,12 @@
         <div class="card action-card">
             <div class="card-header d-flex justify-content-between align-items-center">
                 Azione
-                <button type="button" class="btn-close" aria-label="Close" onclick="this.closest('.action-card').remove()"></button>
+                <div>
+                    {% if not is_new %}
+                    <a href="{{ url_for('edit_action_route', wf=index, idx=action_index) }}" class="btn btn-sm btn-outline-primary">Modifica</a>
+                    {% endif %}
+                    <button type="button" class="btn-close" aria-label="Close" onclick="this.closest('.action-card').remove()"></button>
+                </div>
             </div>
             <div class="card-body">
                 <div class="mb-3">


### PR DESCRIPTION
## Summary
- allow editing trigger or specific actions via new Flask routes
- provide edit views with dropdown selections for triggers or actions
- link edit controls from main workflow page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f61d71bf4832db9384d7b15861ccd