### PR TITLE
Add plugin help page and link from workflow editor

### DIFF
--- a/pyzap/templates/edit_workflow.html
+++ b/pyzap/templates/edit_workflow.html
@@ -8,6 +8,9 @@
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h2>{{ 'Nuovo' if is_new else 'Modifica' }} Workflow</h2>
         <div>
+            <a href="{{ url_for('help_plugins') }}" class="btn btn-info me-2">
+                Guida trigger/action
+            </a>
             <a href="{{ url_for('index') }}" class="btn btn-secondary">
                 <i class="bi bi-x-lg"></i> Annulla
             </a>
@@ -19,30 +22,6 @@
 
     {% if error %}
     <div class="alert alert-danger">{{ error }}</div>
-    {% endif %}
-
-    {% if plugins %}
-    <!-- Help section for available triggers and actions -->
-    <div class="card mb-3" id="plugin-help">
-        <div class="card-header">Guida Trigger e Azioni</div>
-        <div class="card-body">
-            <h5>Trigger</h5>
-            {% for trig in plugins.triggers %}
-            <details class="mb-2">
-                <summary>{{ trig.name }}</summary>
-                <p>{{ trig.doc }}</p>
-            </details>
-            {% endfor %}
-
-            <h5 class="mt-3">Azioni</h5>
-            {% for act in plugins.actions %}
-            <details class="mb-2">
-                <summary>{{ act.name }}</summary>
-                <p>{{ act.doc }}</p>
-            </details>
-            {% endfor %}
-        </div>
-    </div>
     {% endif %}
 
     <!-- Global Settings -->

--- a/pyzap/templates/help_plugins.html
+++ b/pyzap/templates/help_plugins.html
@@ -1,0 +1,24 @@
+{% extends "layout.html" %}
+{% block title %}Guida Trigger/Azioni{% endblock %}
+
+{% block content %}
+<h2>Trigger Disponibili</h2>
+<ul class="list-group mb-4">
+{% for name, cls in triggers.items() %}
+    <li class="list-group-item">
+        <strong>{{ name }}</strong><br>
+        <small>{{ cls.__doc__ }}</small>
+    </li>
+{% endfor %}
+</ul>
+
+<h2>Azioni Disponibili</h2>
+<ul class="list-group">
+{% for name, cls in actions.items() %}
+    <li class="list-group-item">
+        <strong>{{ name }}</strong><br>
+        <small>{{ cls.__doc__ }}</small>
+    </li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/pyzap/webapp.py
+++ b/pyzap/webapp.py
@@ -9,6 +9,7 @@ from flask import (
 )
 from flask_wtf import CSRFProtect
 
+from . import core
 from .core import load_plugins, TRIGGERS, ACTIONS
 import inspect
 import re
@@ -103,6 +104,14 @@ def get_plugins_help():
     return plugins
 
 
+@app.route("/help/plugins")
+def help_plugins():
+    core.load_plugins()
+    return render_template(
+        "help_plugins.html", triggers=core.TRIGGERS, actions=core.ACTIONS
+    )
+
+
 @app.route("/")
 def index():
     cfg = load_config(CONFIG_PATH)
@@ -115,7 +124,6 @@ def index():
 def edit_workflow(index=None):
     cfg = load_config(CONFIG_PATH)
     workflows = _get_workflows(cfg)
-    plugin_help = get_plugins_help()
     is_new = index is None or index >= len(workflows)
 
     if request.method == "POST":
@@ -145,7 +153,6 @@ def edit_workflow(index=None):
                     wf=wf,
                     index=index,
                     is_new=is_new,
-                    plugins=plugin_help,
                     error="Invalid JSON",
                 )
         else:
@@ -183,7 +190,6 @@ def edit_workflow(index=None):
                     wf=wf,
                     index=index,
                     is_new=is_new,
-                    plugins=plugin_help,
                     error="Invalid JSON",
                 )
         else:
@@ -239,7 +245,6 @@ def edit_workflow(index=None):
         wf=wf,
         index=index,
         is_new=is_new,
-        plugins=plugin_help,
     )
 
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -130,3 +130,10 @@ def test_edit_workflow_via_form(tmp_path, monkeypatch):
     assert wf["id"] == "wf1_mod"
     assert wf["trigger"]["query"] == "new-query"
     assert wf["trigger"]["token_file"] == "token.json"
+
+
+def test_help_plugins_route():
+    client = app.test_client()
+    resp = client.get("/help/plugins")
+    assert resp.status_code == 200
+    assert b"Trigger Disponibili" in resp.data


### PR DESCRIPTION
## Summary
- add `/help/plugins` route to reload plugins and render trigger/action docs
- provide `help_plugins.html` template to list available plugins
- link to plugin help page from workflow editor and add unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f79a65a48832d8889a2064c469030