### PR TITLE
Remove plugin help link from index

### DIFF
--- a/pyzap/templates/index.html
+++ b/pyzap/templates/index.html
@@ -21,12 +21,9 @@
 <div class="card">
     <div class="card-header d-flex justify-content-between align-items-center">
         Workflows
-        <div>
-            <a href="{{ url_for('edit_workflow') }}#plugin-help" class="btn btn-link">Guida Trigger/Azioni</a>
-            <a href="{{ url_for('edit_workflow') }}" class="btn btn-primary">
-                <i class="bi bi-plus-circle"></i> Nuovo Workflow
-            </a>
-        </div>
+        <a href="{{ url_for('edit_workflow') }}" class="btn btn-primary">
+            <i class="bi bi-plus-circle"></i> Nuovo Workflow
+        </a>
     </div>
     <div class="list-group list-group-flush">
         {% for wf in workflows %}


### PR DESCRIPTION
## Summary
- remove trigger/action guide link from workflow index page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f7f722e5c832da28f3a322e881ca7