### PR TITLE
Display plugin parameters on help page

### DIFF
--- a/pyzap/templates/help_plugins.html
+++ b/pyzap/templates/help_plugins.html
@@ -4,20 +4,34 @@
 {% block content %}
 <h2>Trigger Disponibili</h2>
 <ul class="list-group mb-4">
-{% for name, cls in triggers.items() %}
+{% for trig in triggers %}
     <li class="list-group-item">
-        <strong>{{ name }}</strong><br>
-        <small>{{ cls.__doc__ }}</small>
+        <strong>{{ trig.name }}</strong><br>
+        <small>{{ trig.doc }}</small>
+        {% if trig.params %}
+        <ul class="mt-2">
+        {% for param in trig.params %}
+            <li><code>{{ param.name }}</code>{% if not param.required %} (opzionale){% endif %}</li>
+        {% endfor %}
+        </ul>
+        {% endif %}
     </li>
 {% endfor %}
 </ul>
 
 <h2>Azioni Disponibili</h2>
 <ul class="list-group">
-{% for name, cls in actions.items() %}
+{% for act in actions %}
     <li class="list-group-item">
-        <strong>{{ name }}</strong><br>
-        <small>{{ cls.__doc__ }}</small>
+        <strong>{{ act.name }}</strong><br>
+        <small>{{ act.doc }}</small>
+        {% if act.params %}
+        <ul class="mt-2">
+        {% for param in act.params %}
+            <li><code>{{ param.name }}</code>{% if not param.required %} (opzionale){% endif %}</li>
+        {% endfor %}
+        </ul>
+        {% endif %}
     </li>
 {% endfor %}
 </ul>

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -188,4 +188,6 @@ def test_help_plugins_route():
     resp = client.get("/help/plugins")
     assert resp.status_code == 200
     assert b"Trigger Disponibili" in resp.data
+    assert b"host" in resp.data
+    assert b"folder_id" in resp.data
 


### PR DESCRIPTION
## Summary
- show trigger and action parameter info on the help page
- extract parameters from both constructors and docstrings
- test help page lists known parameters

## Testing
- `pytest` *(fails: No module named 'PyPDF2'; No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688f8b9698ec832db2d6903a053c3f83