### PR TITLE
Document plugin parameters and regenerate help page

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,25 +5,108 @@ This page lists all available triggers and actions provided by PyZap.
 ## Triggers
 
 - `excel_poll` – Poll an Excel workbook for newly appended rows.
+  - `file`: Path to the workbook.
+  - `sheet` (optional): Worksheet name to read.
+  - `state_file` (optional): File used to persist the last processed row.
+  - `start_row` (optional): Starting row number, defaults to 2.
+  - `filters` (optional): Mapping of column numbers to expected values.
 - `excel_row_added` – Detect new rows with optional advanced filtering.
+  - `file`: Path to the workbook.
+  - `sheet` (optional): Worksheet name to read.
+  - `state_file` (optional): File used to persist the last processed row.
+  - `start_row` (optional): Starting row number, defaults to 2.
+  - `filters` (optional): Mapping of column numbers to expected values or conditions.
 - `excel_cell_change` – Trigger when monitored cells change value.
+  - `file`: Path to the workbook.
+  - `sheet` (optional): Worksheet name to read.
+  - `state_file` (optional): File used to persist previous values.
+  - `start_row` (optional): First row to monitor, defaults to 2.
+  - `columns`: List of column numbers to watch for changes.
 - `excel_file_updated` – Trigger when the Excel file modification time changes.
+  - `file`: Path to the workbook.
+  - `state_file` (optional): File used to store the last modification time.
 - `excel_attachment_row` – Trigger on new rows where an attachment column contains data.
+  - `file`: Path to the workbook.
+  - `sheet` (optional): Worksheet name to read.
+  - `state_file` (optional): File used to persist the last processed row.
+  - `start_row` (optional): Starting row number, defaults to 2.
+  - `filters` (optional): Mapping of column numbers to expected values or conditions.
+  - `attachment_column`: Column number containing attachment data.
 - `gmail_poll` – Poll Gmail using the Gmail API.
+  - `token_file`: Path to a Gmail OAuth token JSON file.
+  - `query`: Gmail search query string.
+  - `max_results` (optional): Maximum number of messages to return.
+  - `accounts` (optional): List of per-account configurations with the same keys.
 - `imap_poll` – Poll an IMAP server for new messages.
+  - `host`: IMAP server hostname.
+  - `username`: Login username.
+  - `password`: Login password.
+  - `mailbox` (optional): Mailbox to select, defaults to `INBOX`.
+  - `search` (optional): IMAP search query, defaults to `UNSEEN`.
 
 ## Actions
 
 - `excel_append` – Append data to an Excel workbook.
+  - `file`: Path to the workbook.
+  - `sheet` (optional): Worksheet name to write to.
+  - `fields` (optional): Ordered list of fields to append.
+  - `max_message_length` (optional): Truncate message fields to this length.
 - `excel_write_row` – Create or update rows in an Excel file.
+  - `file`: Path to the workbook.
+  - `sheet` (optional): Worksheet name to write to.
+  - `row` (optional): Row number to update; appends when omitted.
 - `email_send` – Send an email using SMTP.
+  - `host` (optional): SMTP server, defaults to `localhost`.
+  - `port` (optional): SMTP port, defaults to 25.
+  - `username` (optional): SMTP username.
+  - `password` (optional): SMTP password.
+  - `from_addr`: Sender email address.
+  - `to_addr`: Recipient email address.
+  - `subject` (optional): Email subject.
+  - `body` (optional): Message body.
 - `db_save` – Save data into a SQLite database.
+  - `db`: Path to the SQLite database file.
+  - `table` (optional): Table name, defaults to `data`.
 - `file_create` – Create a file from row data.
+  - `path`: Destination file path.
+  - `format` (optional): Output format `txt`, `json` or `csv`.
 - `attachment_download` – Download attachments referenced in a row.
+  - `dest`: Directory where files are stored.
+  - `rename` (optional): Filename template using row placeholders.
 - `g_drive_upload` – Upload a file to Google Drive.
+  - `folder_id`: Destination Drive folder ID.
+  - `token` (optional): OAuth bearer token.
 - `gmail_archive` – Download a Gmail message and attachments and store them.
+  - `token_file`: Path to a Gmail OAuth token JSON file.
+  - `drive_folder_id` (optional): Drive folder ID for storage.
+  - `local_dir` (optional): Local directory for storage.
+  - `token` (optional): OAuth bearer token used for Drive uploads.
+  - `save_message` (optional): Save the email body, defaults to `true`.
+  - `save_attachments` (optional): Download attachments, defaults to `true`.
+  - `download_links` (optional): Fetch files referenced by URLs in the body.
+  - `attachment_types` (optional): List of allowed attachment extensions.
 - `imap_archive` – Download an IMAP message and attachments and store them.
+  - `host`: IMAP server hostname.
+  - `username`: Login username.
+  - `password`: Login password.
+  - `mailbox` (optional): Mailbox to select, defaults to `INBOX`.
+  - `drive_folder_id` (optional): Drive folder ID for storage.
+  - `local_dir` (optional): Local directory for storage.
+  - `token` (optional): OAuth bearer token used for Drive uploads.
+  - `save_attachments` (optional): Download attachments, defaults to `true`.
 - `pdf_split` – Split a PDF file into smaller PDFs.
+  - `output_dir`: Directory where split files are written.
+  - `pattern` (optional): Regular expression marking the start of a new file.
+  - `name_template` (optional): Template for output filenames.
+  - `regex_fields` (optional): Mapping of field names to regex patterns to extract.
+  - `table_fields` (optional): Fields to extract from table rows.
+  - `parse_invoice` (optional): Parse invoice data from chunks.
+  - `date_formats` (optional): Mapping of field names to `strftime` formats.
 - `sheets_append` – Append data to a Google Sheet.
+  - `sheet_id`: ID of the target spreadsheet.
+  - `range`: Target range for the append.
+  - `token` (optional): OAuth bearer token.
+  - `fields` (optional): Ordered list of data keys if `values` not supplied.
 - `slack_notify` – Send a notification to Slack via webhook.
+  - `webhook_url`: Slack webhook URL.
 

--- a/help/plugins.html
+++ b/help/plugins.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="it">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Guida Trigger/Azioni - PyZap Dashboard</title>
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+          crossorigin="anonymous">
+    <!-- Bootstrap Icons -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <style>
+        body { background-color: #f8f9fa; }
+        .container { max-width: 960px; }
+        .card { margin-bottom: 1.5rem; }
+    </style>
+</head>
+<body>
+    <div class="container mt-4">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+             <a href="/" class="text-decoration-none text-dark">
+                <h1><i class="bi bi-robot"></i> PyZap Dashboard</h1>
+            </a>
+            <a href="/config/upload" class="btn btn-outline-secondary">
+                <i class="bi bi-upload"></i> Carica config
+            </a>
+        </div>
+        
+<h2>Trigger Disponibili</h2>
+<ul class="list-group mb-4">
+
+    <li class="list-group-item">
+        <strong>imap_poll</strong><br>
+        <small>Poll an IMAP server for new messages.</small>
+        
+        <ul class="mt-2">
+        
+            <li><code>host</code></li>
+        
+            <li><code>username</code></li>
+        
+            <li><code>mailbox</code> (opzionale)</li>
+        
+            <li><code>search</code> (opzionale)</li>
+        
+        </ul>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>gmail_poll</strong><br>
+        <small>Poll Gmail using the Gmail API.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>excel_poll</strong><br>
+        <small>Poll an Excel workbook for newly appended rows.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>excel_attachment_row</strong><br>
+        <small>Trigger on new rows where an attachment column contains data.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>excel_cell_change</strong><br>
+        <small>Trigger when monitored cells change value.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>excel_file_updated</strong><br>
+        <small>Trigger when the Excel file modification time changes.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>excel_row_added</strong><br>
+        <small>Detect new rows with optional advanced filtering.</small>
+        
+    </li>
+
+</ul>
+
+<h2>Azioni Disponibili</h2>
+<ul class="list-group">
+
+    <li class="list-group-item">
+        <strong>g_drive_upload</strong><br>
+        <small>Upload a file to Google Drive.</small>
+        
+        <ul class="mt-2">
+        
+            <li><code>folder_id</code></li>
+        
+            <li><code>token</code> (opzionale)</li>
+        
+        </ul>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>imap_archive</strong><br>
+        <small>Download an IMAP message and attachments and store them.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>excel_append</strong><br>
+        <small>Append data to an Excel workbook.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>pdf_split</strong><br>
+        <small>Split a PDF file into smaller PDFs.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>slack_notify</strong><br>
+        <small>Send a notification to Slack via webhook.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>sheets_append</strong><br>
+        <small>Append data to a Google Sheet.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>gmail_archive</strong><br>
+        <small>Download a Gmail message and attachments and store them.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>attachment_download</strong><br>
+        <small>Download attachments referenced in a row.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>db_save</strong><br>
+        <small>Save data into a SQLite database.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>email_send</strong><br>
+        <small>Send an email using SMTP.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>excel_write_row</strong><br>
+        <small>Create or update rows in an Excel file.</small>
+        
+    </li>
+
+    <li class="list-group-item">
+        <strong>file_create</strong><br>
+        <small>Create a file from row data.</small>
+        
+    </li>
+
+</ul>
+
+    </div>
+
+    <!-- Bootstrap JS Bundle -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+            crossorigin="anonymous"></script>
+    
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document parameters for every trigger and action in plugin reference
- regenerate static `help/plugins` page with current plugin metadata

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f8dc4e434832dbd51371648459d31