### PR TITLE
Remove dest path from upload config form

### DIFF
--- a/pyzap/templates/upload_config.html
+++ b/pyzap/templates/upload_config.html
@@ -11,10 +11,6 @@
     <label for="config_file" class="form-label">File JSON</label>
     <input class="form-control" type="file" id="config_file" name="config_file" accept="application/json" required>
   </div>
-  <div class="mb-3">
-    <label for="dest_path" class="form-label">Percorso di destinazione</label>
-    <input class="form-control" type="text" id="dest_path" name="dest_path" required>
-  </div>
   <button type="submit" class="btn btn-primary">Carica</button>
 </form>
 {% endblock %}

--- a/pyzap/webapp.py
+++ b/pyzap/webapp.py
@@ -158,13 +158,13 @@ def index():
 def upload_config():
     if request.method == "POST":
         file = request.files.get("config_file")
-        dest_path = request.form.get("dest_path")
-        if not file or not dest_path:
-            return render_template("upload_config.html", error="File o percorso mancante")
+        if not file:
+            return render_template("upload_config.html", error="File mancante")
         try:
             data = json.load(file)
         except json.JSONDecodeError:
             return render_template("upload_config.html", error="Invalid JSON")
+        dest_path = get_config_path()
         save_config(dest_path, data)
         set_config_path(dest_path)
         return redirect(url_for("index"))

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -140,10 +140,11 @@ def test_edit_workflow_via_form(tmp_path):
 def test_upload_config(tmp_path):
     cfg_path = tmp_path / "uploaded.json"
     client = app.test_client()
+    _set_config_path(client, str(cfg_path))
     data = BytesIO(json.dumps({"workflows": []}).encode("utf-8"))
     resp = client.post(
         "/config/upload",
-        data={"config_file": (data, "cfg.json"), "dest_path": str(cfg_path)},
+        data={"config_file": (data, "cfg.json")},
         content_type="multipart/form-data",
         follow_redirects=True,
     )


### PR DESCRIPTION
## Summary
- simplify upload_config form by removing destination path field
- default upload to current configuration path and adjust backend logic
- update webapp tests for new upload behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f91465564832da07204b2c7e6435d