### PR TITLE
Document plugin parameters in help page

### DIFF
--- a/pyzap/templates/help_plugins.html
+++ b/pyzap/templates/help_plugins.html
@@ -1,0 +1,40 @@
+{% extends "layout.html" %}
+{% block title %}Plugins{% endblock %}
+
+{% block content %}
+<h2>Trigger</h2>
+{% for trig in triggers %}
+<div class="card">
+  <div class="card-header">{{ trig.name }}</div>
+  <div class="card-body">
+    {% if trig.params %}
+    <ul class="mb-0">
+      {% for p in trig.params %}
+      <li><code>{{ p.name }}</code>{% if p.desc %}: {{ p.desc }}{% endif %}</li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <p class="mb-0 text-muted">Nessun parametro.</p>
+    {% endif %}
+  </div>
+</div>
+{% endfor %}
+
+<h2 class="mt-4">Azioni</h2>
+{% for act in actions %}
+<div class="card">
+  <div class="card-header">{{ act.name }}</div>
+  <div class="card-body">
+    {% if act.params %}
+    <ul class="mb-0">
+      {% for p in act.params %}
+      <li><code>{{ p.name }}</code>{% if p.desc %}: {{ p.desc }}{% endif %}</li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <p class="mb-0 text-muted">Nessun parametro.</p>
+    {% endif %}
+  </div>
+</div>
+{% endfor %}
+{% endblock %}

--- a/tests/test_help_plugins.py
+++ b/tests/test_help_plugins.py
@@ -1,0 +1,13 @@
+from pyzap.webapp import app, get_plugins_info
+
+
+def test_plugins_help_page_lists_all_params():
+    info = get_plugins_info()
+    client = app.test_client()
+    resp = client.get("/help/plugins")
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    for section in info["triggers"] + info["actions"]:
+        assert section["name"] in html
+        for param in section["params"]:
+            assert f"<code>{param['name']}</code>" in html


### PR DESCRIPTION
## Summary
- list trigger/action plugins with parameters on `/help/plugins`
- implement plugin metadata extraction and help route
- cover help page with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9a927478832d89be0eb6f2e965b5