### PR TITLE
Remove duplicate help_plugins route

### DIFF
--- a/pyzap/templates/help_plugins.html
+++ b/pyzap/templates/help_plugins.html
@@ -2,7 +2,7 @@
 {% block title %}Plugins{% endblock %}
 
 {% block content %}
-<h2>Trigger</h2>
+<h2>Trigger Disponibili</h2>
 {% for trig in triggers %}
 <div class="card">
   <div class="card-header">{{ trig.name }}</div>
@@ -20,7 +20,7 @@
 </div>
 {% endfor %}
 
-<h2 class="mt-4">Azioni</h2>
+<h2 class="mt-4">Azioni Disponibili</h2>
 {% for act in actions %}
 <div class="card">
   <div class="card-header">{{ act.name }}</div>

--- a/pyzap/webapp.py
+++ b/pyzap/webapp.py
@@ -125,28 +125,8 @@ def get_plugins_help():
 
 @app.route("/help/plugins")
 def help_plugins():
-    core.load_plugins()
-    trigger_info = []
-    for name, cls in core.TRIGGERS.items():
-        trigger_info.append(
-            {
-                "name": name,
-                "doc": cls.__doc__ or "",
-                "params": _get_plugin_params(cls, is_trigger=True),
-            }
-        )
-    action_info = []
-    for name, cls in core.ACTIONS.items():
-        action_info.append(
-            {
-                "name": name,
-                "doc": cls.__doc__ or "",
-                "params": _get_plugin_params(cls, is_trigger=False),
-            }
-        )
-    return render_template(
-        "help_plugins.html", triggers=trigger_info, actions=action_info
-    )
+    info = get_plugins_info()
+    return render_template("help_plugins.html", **info)
 
 
 def _extract_params(cls, is_trigger):
@@ -498,12 +478,6 @@ def create_workflow_api():
         _save_config(workflows, path)
 
     return jsonify({"status": "ok"})
-
-
-@app.route("/help/plugins")
-def help_plugins():
-    info = get_plugins_info()
-    return render_template("help_plugins.html", **info)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- consolidate `/help/plugins` into a single view using `get_plugins_info`
- update plugins help template headings for triggers/actions

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa199ba0c832dbc8c0b87e11c52b2