### PR TITLE
refactor: unify plugin metadata helpers

### DIFF
--- a/tests/test_help_plugins.py
+++ b/tests/test_help_plugins.py
@@ -1,8 +1,8 @@
-from pyzap.webapp import app, get_plugins_info
+from pyzap.webapp import app, get_plugins_metadata
 
 
 def test_plugins_help_page_lists_all_params():
-    info = get_plugins_info()
+    info = get_plugins_metadata()
     client = app.test_client()
     resp = client.get("/help/plugins")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- merge plugin help/info helpers into `get_plugins_metadata`
- update `/help/plugins` view to use new helper
- align tests with unified helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fad9591f8832db19619e096145b4f