### PR TITLE
Use environment variables for IMAP credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ SMTP credentials used for failure notifications:
 }
 ```
 
+When using the example `config.imap.json`, IMAP credentials are read from the
+environment. Define `IMAP_EMAIL_01` and `IMAP_PASSWORD_01` before running the
+application:
+
+```bash
+export IMAP_EMAIL_01="nomecasella@nomedominio.it"
+export IMAP_PASSWORD_01="la password legata alla casella"
+```
+
 ## Email polling triggers
 
 Two built-in triggers allow fetching messages from email servers:

--- a/config.imap.json
+++ b/config.imap.json
@@ -6,8 +6,8 @@
         "type": "imap_poll",
         "host": "in.postassl.it",
         "port": 995,
-        "username": "nomecasella@nomedominio.it",
-        "password": "la password legata alla casella"
+        "username": "${IMAP_EMAIL_01}",
+        "password": "${IMAP_PASSWORD_01}"
       },
       "actions": [
         {
@@ -15,8 +15,8 @@
           "params": {
             "host": "in.postassl.it",
             "port": 995,
-            "username": "nomecasella@nomedominio.it",
-            "password": "la password legata alla casella",
+            "username": "${IMAP_EMAIL_01}",
+            "password": "${IMAP_PASSWORD_01}",
             "local_dir": "./email_attachments"
           }
         },


### PR DESCRIPTION
## Summary
- Load IMAP username and password from `IMAP_EMAIL_01` and `IMAP_PASSWORD_01` in `config.imap.json`
- Document required IMAP environment variables in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fb1aed290832d85d63de37d4ad67e