### PR TITLE
Improve parameter detection for trigger/action editor

### DIFF
--- a/pyzap/webapp.py
+++ b/pyzap/webapp.py
@@ -107,6 +107,12 @@ def _get_plugin_params(cls, *, is_trigger: bool):
             if p["name"] not in existing:
                 params.append(p)
                 existing.add(p["name"])
+    if not params:
+        for p in _extract_params(cls, is_trigger):
+            name = p["name"]
+            if name not in existing:
+                params.append({"name": name, "required": False})
+                existing.add(name)
     return params
 
 


### PR DESCRIPTION
## Summary
- ensure trigger/action edit forms show plugin parameters even when not declared in function signatures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fb53455c4832db3ae8a5215fe73c1