### PR TITLE
fix: add trailing comma in IMAP config

### DIFF
--- a/config.imap.json
+++ b/config.imap.json
@@ -7,8 +7,8 @@
         "host": "in.postassl.it",
         "port": 995,
         "username": "${IMAP_EMAIL_01}",
-        "password": "${IMAP_PASSWORD_01}"
-		"search": "UNSEEN"
+        "password": "${IMAP_PASSWORD_01}",
+        "search": "UNSEEN"
       },
       "actions": [
         {


### PR DESCRIPTION
## Summary
- add missing comma after password in IMAP trigger config

## Testing
- `python -m json.tool config.imap.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fc386c98c832d849f388b214b4fdf