### PR TITLE
Handle invalid JSON in config loading

### DIFF
--- a/pyzap/config.py
+++ b/pyzap/config.py
@@ -55,7 +55,10 @@ def _substitute_env_vars(data: Any) -> Any:
 def load_config(path: str) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
     """Load configuration from JSON file with environment variable substitution."""
     with open(path, "r", encoding="utf-8") as fh:
-        raw_config = json.load(fh)
+        try:
+            raw_config = json.load(fh)
+        except json.JSONDecodeError as err:
+            raise SystemExit(f"Invalid JSON in {path}: {err}") from err
     cleaned = _strip_comments(raw_config)
     return _substitute_env_vars(cleaned)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -35,3 +37,13 @@ def test_load_config_env_vars_and_comments(monkeypatch, tmp_path):
     path.write_text(json.dumps(data))
     cfg = load_config(str(path))
     assert cfg == {"num": "42"}
+
+
+def test_load_config_invalid_json(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("{bad json")
+
+    with pytest.raises(SystemExit) as excinfo:
+        load_config(str(path))
+
+    assert str(excinfo.value).startswith(f"Invalid JSON in {path}:")


### PR DESCRIPTION
## Summary
- handle invalid JSON in `load_config` with a clear SystemExit message
- add unit test ensuring malformed config files are reported cleanly

## Testing
- `pytest tests/test_config.py::test_load_config_invalid_json -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fc5defa60832da0150cdbf9beb0dc