### PR TITLE
Handle multipart emails in IMAP polling trigger

### DIFF
--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -248,6 +248,53 @@ def test_imap_poll_max_results(monkeypatch):
     )
     msgs = trigger.poll()
     assert [m["id"] for m in msgs] == ["1", "2", "3"]
+    
+
+def test_imap_poll_multipart(monkeypatch):
+    from pyzap.plugins.imap_poll import ImapPollTrigger
+
+    class DummyIMAP:
+        def __init__(self, host, port):
+            pass
+
+        def login(self, user, pwd):
+            pass
+
+        def select(self, mbox):
+            pass
+
+        def search(self, charset, query):
+            return ("OK", [b"1"])
+
+        def fetch(self, num, parts):
+            msg = (
+                "Subject: s\r\n"
+                "From: f\r\n"
+                "MIME-Version: 1.0\r\n"
+                "Content-Type: multipart/alternative; boundary=\"b\"\r\n"
+                "\r\n"
+                "--b\r\n"
+                "Content-Type: text/plain; charset=utf-8\r\n"
+                "\r\n"
+                "Plain body\r\n"
+                "--b\r\n"
+                "Content-Type: text/html; charset=utf-8\r\n"
+                "\r\n"
+                "<p>HTML</p>\r\n"
+                "--b--\r\n"
+            ).encode("utf-8")
+            return ("OK", [(b"1", msg)])
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(imaplib, "IMAP4_SSL", lambda host, port=993: DummyIMAP(host, port))
+    trigger = ImapPollTrigger({"host": "h", "username": "u", "password": "p"})
+    msgs = trigger.poll()
+    assert msgs[0]["body"].strip() == "Plain body"
 
 
 def test_imap_poll_missing_config():


### PR DESCRIPTION
## Summary
- Safely decode IMAP message bodies by checking for multipart content and selecting the first text/plain part
- Decode non-multipart messages only when a payload exists
- Add regression test ensuring multipart emails return their text body without errors

## Testing
- `pytest tests/test_trigger.py::test_imap_poll tests/test_trigger.py::test_imap_poll_max_results tests/test_trigger.py::test_imap_poll_multipart -q`

------
https://chatgpt.com/codex/tasks/task_e_688fcddb9f7c832d99009501ad2caa50