### PR TITLE
Include mark_seen flag in IMAP poll test

### DIFF
--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -210,7 +210,7 @@ def test_imap_poll(monkeypatch):
             pass
 
     monkeypatch.setattr(imaplib, "IMAP4_SSL", lambda host, port=993: DummyIMAP(host, port))
-    trigger = ImapPollTrigger({"host": "h", "username": "u", "password": "p", "port": 123})
+    trigger = ImapPollTrigger({"host": "h", "username": "u", "password": "p", "port": 123, "mark_seen": False})
     msgs = trigger.poll()
     assert [m["id"] for m in msgs] == ["1", "2"]
     assert captured["port"] == 123


### PR DESCRIPTION
## Summary
- ensure IMAP poll test covers explicit mark_seen configuration

## Testing
- `pytest tests/test_trigger.py::test_imap_poll -q`

------
https://chatgpt.com/codex/tasks/task_e_689314ef3f44832daf7c9f2a7e81a3fc