### PR TITLE
Support date formatting in excel_append action

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,18 @@ metadata into spreadsheet appenders:
 
 The `excel_append` action also accepts a `records` key containing a list of
 objects with the same fields configured in `fields`, allowing multiple rows to
-be appended in one execution.
+be appended in one execution. Date fields can be formatted with the
+`date_formats` option which maps field names to `strftime` patterns:
+
+```json
+{
+  "type": "excel_append",
+  "params": {
+    "file": "log.xlsx",
+    "date_formats": {"created_at": "%d/%m/%Y"}
+  }
+}
+```
 
 `pdf_split` will use the `attachment_paths` field from `gmail_archive` when
 `pdf_path` is not provided.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -58,6 +58,8 @@ This page lists all available triggers and actions provided by PyZap.
   - `sheet` (optional): Worksheet name to write to.
   - `fields` (optional): Ordered list of fields to append.
   - `max_message_length` (optional): Truncate message fields to this length.
+  - `date_formats` (optional): Mapping of field names to `strftime` patterns.
+    Example: `{ "created_at": "%d/%m/%Y" }`.
 - `excel_write_row` – Create or update rows in an Excel file.
   - `file`: Path to the workbook.
   - `sheet` (optional): Worksheet name to write to.

--- a/pyzap/plugins/excel_append.py
+++ b/pyzap/plugins/excel_append.py
@@ -6,6 +6,8 @@ import json
 import email.utils
 from typing import Any, Dict, List
 
+from ..formatter import parse_date
+
 
 
 from ..core import BaseAction
@@ -33,6 +35,7 @@ class ExcelAppendAction(BaseAction):
                 max_message_length = int(max_message_length)
             except Exception:
                 max_message_length = None
+        date_formats: Dict[str, str] = self.params.get("date_formats", {})
         message_fields = {"summary", "body", "message"}
         if not file_path:
             raise ValueError("file parameter required")
@@ -69,6 +72,11 @@ class ExcelAppendAction(BaseAction):
                         try:
                             dt = email.utils.parsedate_to_datetime(value)
                             value = dt.strftime("%d/%m/%Y %H:%M:%S")
+                        except Exception:
+                            pass
+                    if name in date_formats and isinstance(value, str):
+                        try:
+                            value = parse_date(value).strftime(date_formats[name])
                         except Exception:
                             pass
                     if name == "attachments" and isinstance(value, (list, tuple)):

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -979,6 +979,30 @@ def test_excel_append_datetime_format(monkeypatch, tmp_path):
     assert row == ['26/07/2025 04:23:18']
 
 
+def test_excel_append_date_formats(monkeypatch, tmp_path):
+    _setup_openpyxl(monkeypatch)
+    import importlib
+    openpyxl = importlib.import_module('openpyxl')
+    ExcelAppendAction = importlib.import_module('pyzap.plugins.excel_append').ExcelAppendAction
+
+    file_path = tmp_path / 'book.xlsx'
+    wb = openpyxl.Workbook()
+    wb.save(file_path)
+
+    action = ExcelAppendAction(
+        {
+            'file': str(file_path),
+            'fields': ['date'],
+            'date_formats': {'date': '%d/%m/%Y'},
+        }
+    )
+    action.execute({'date': '2025-07-23'})
+
+    wb2 = openpyxl.load_workbook(file_path)
+    row = [cell.value for cell in wb2.active[1]]
+    assert row == ['23/07/2025']
+
+
 def test_excel_append_message_truncate(monkeypatch, tmp_path):
     _setup_openpyxl(monkeypatch)
     import importlib


### PR DESCRIPTION
## Summary
- allow `excel_append` to format string dates using `parse_date` and a new `date_formats` parameter
- document `date_formats` option for `excel_append`
- test Excel date formatting when `date_formats` is provided

## Testing
- `pytest tests/test_action.py::test_excel_append_date_formats -q`

------
https://chatgpt.com/codex/tasks/task_e_6895ac65eca0832da8ddb28c67ca46d3