### PR TITLE
Support date formatting in excel_append action

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,18 @@ metadata into spreadsheet appenders:
 
 The `excel_append` action also accepts a `records` key containing a list of
 objects with the same fields configured in `fields`, allowing multiple rows to
-be appended in one execution.
+be appended in one execution. Date fields can be formatted with the
+`date_formats` option which maps field names to `strftime` patterns:
+
+```json
+{
+  "type": "excel_append",
+  "params": {
+    "file": "log.xlsx",
+    "date_formats": {"created_at": "%d/%m/%Y"}
+  }
+}
+```
 
 `pdf_split` will use the `attachment_paths` field from `gmail_archive` when
 `pdf_path` is not provided.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -58,6 +58,8 @@ This page lists all available triggers and actions provided by PyZap.
   - `sheet` (optional): Worksheet name to write to.
   - `fields` (optional): Ordered list of fields to append.
   - `max_message_length` (optional): Truncate message fields to this length.
+  - `date_formats` (optional): Mapping of field names to `strftime` patterns.
+    Example: `{ "created_at": "%d/%m/%Y" }`.
 - `excel_write_row` – Create or update rows in an Excel file.
   - `file`: Path to the workbook.
   - `sheet` (optional): Worksheet name to write to.

--- a/help/plugins.html
+++ b/help/plugins.html
@@ -228,6 +228,8 @@
 
             <li><code>max_message_length</code> (opzionale)</li>
 
+            <li><code>date_formats</code> (opzionale)</li>
+
         </ul>
 
     </li>

--- a/pyzap/plugins/excel_append.py
+++ b/pyzap/plugins/excel_append.py
@@ -6,6 +6,8 @@ import json
 import email.utils
 from typing import Any, Dict, List
 
+from ..formatter import parse_date
+
 
 
 from ..core import BaseAction
@@ -33,6 +35,7 @@ class ExcelAppendAction(BaseAction):
                 max_message_length = int(max_message_length)
             except Exception:
                 max_message_length = None
+        date_formats: Dict[str, str] = self.params.get("date_formats", {})
         message_fields = {"summary", "body", "message"}
         if not file_path:
             raise ValueError("file parameter required")
@@ -69,6 +72,11 @@ class ExcelAppendAction(BaseAction):
                         try:
                             dt = email.utils.parsedate_to_datetime(value)
                             value = dt.strftime("%d/%m/%Y %H:%M:%S")
+                        except Exception:
+                            pass
+                    if name in date_formats and isinstance(value, str):
+                        try:
+                            value = parse_date(value).strftime(date_formats[name])
                         except Exception:
                             pass
                     if name == "attachments" and isinstance(value, (list, tuple)):

--- a/pyzap/templates/edit_action.html
+++ b/pyzap/templates/edit_action.html
@@ -20,9 +20,10 @@
     </div>
     <h5>Parametri</h5>
     {% for p in params %}
+    {% set val = values.get(p.name) %}
     <div class="mb-3">
         <label class="form-label">{{ p.name }}</label>
-        <input type="text" class="form-control" name="{{ p.name }}" value="{{ values.get(p.name, '') }}" {% if p.required %}required{% endif %}>
+        <input type="text" class="form-control" name="{{ p.name }}" value="{{ (val|tojson) if val is mapping or val is sequence else (val if val is not none else '') }}" {% if p.required %}required{% endif %}>
     </div>
     {% endfor %}
     <div class="mt-3">

--- a/pyzap/templates/edit_workflow.html
+++ b/pyzap/templates/edit_workflow.html
@@ -140,7 +140,9 @@
         actions.forEach((action, idx) => {
             const params = action.params || {};
             const entries = Object.entries(params);
-            const paramsHtml = entries.length ? '<ul class="mb-0">' + entries.map(([k,v]) => `<li>${k}: ${v}</li>`).join('') + '</ul>' : '';
+            const paramsHtml = entries.length
+                ? '<ul class="mb-0">' + entries.map(([k,v]) => `<li>${k}: ${typeof v === 'object' ? JSON.stringify(v) : v}</li>`).join('') + '</ul>'
+                : '';
             const card = document.createElement('div');
             card.className = 'card mb-2';
             let buttons = `<button type="button" class="btn btn-sm btn-danger" onclick="removeAction(${idx})">Cancella</button>`;

--- a/pyzap/webapp.py
+++ b/pyzap/webapp.py
@@ -435,6 +435,10 @@ def edit_action_route(wf, idx):
             for param in _get_plugin_params(cls, is_trigger=False):
                 value = request.form.get(param["name"])
                 if value:
+                    try:
+                        value = json.loads(value)
+                    except json.JSONDecodeError:
+                        pass
                     action["params"][param["name"]] = value
         workflows[wf]["actions"][idx] = action
         if isinstance(cfg, dict):

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -979,6 +979,30 @@ def test_excel_append_datetime_format(monkeypatch, tmp_path):
     assert row == ['26/07/2025 04:23:18']
 
 
+def test_excel_append_date_formats(monkeypatch, tmp_path):
+    _setup_openpyxl(monkeypatch)
+    import importlib
+    openpyxl = importlib.import_module('openpyxl')
+    ExcelAppendAction = importlib.import_module('pyzap.plugins.excel_append').ExcelAppendAction
+
+    file_path = tmp_path / 'book.xlsx'
+    wb = openpyxl.Workbook()
+    wb.save(file_path)
+
+    action = ExcelAppendAction(
+        {
+            'file': str(file_path),
+            'fields': ['date'],
+            'date_formats': {'date': '%d/%m/%Y'},
+        }
+    )
+    action.execute({'date': '2025-07-23'})
+
+    wb2 = openpyxl.load_workbook(file_path)
+    row = [cell.value for cell in wb2.active[1]]
+    assert row == ['23/07/2025']
+
+
 def test_excel_append_message_truncate(monkeypatch, tmp_path):
     _setup_openpyxl(monkeypatch)
     import importlib


### PR DESCRIPTION
## Summary
- allow `excel_append` to format string dates using `parse_date` and a new `date_formats` parameter
- document `date_formats` option for `excel_append`
- test Excel date formatting when `date_formats` is provided
- enable web UI to parse JSON parameters like `date_formats`

## Testing
- `pytest tests/test_webapp.py::test_edit_action_parses_json_params tests/test_help_plugins.py::test_plugins_help_page_lists_all_params -q` *(fails: No module named 'flask')*
- `pip install flask flask-wtf` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_6895ac65eca0832da8ddb28c67ca46d3